### PR TITLE
fixed preconditioning

### DIFF
--- a/commit/core.py
+++ b/commit/core.py
@@ -690,9 +690,9 @@ class Evaluation :
         # x_map is the x used to generate the intra-cellular, extra-cellular and isotropic maps (not divided by norm of the fiber)
         if self.get_config('doNormalizeKernels') :
             # renormalize the coefficients
-            norm1 = np.tile(self.KERNELS['wmr_norm'],(nF,1)).T.ravel()
-            norm2 = np.tile(self.KERNELS['wmh_norm'],(nE,1)).T.ravel()
-            norm3 = np.tile(self.KERNELS['iso_norm'],(nV,1)).T.ravel()
+            norm1 = np.repeat(self.KERNELS['wmr_norm'],(nF,1)).T.ravel()
+            norm2 = np.repeat(self.KERNELS['wmh_norm'],(nE,1)).T.ravel()
+            norm3 = np.repeat(self.KERNELS['iso_norm'],(nV,1)).T.ravel()
             norm_fib = np.kron(np.ones(self.KERNELS['wmr'].shape[0]), self.DICTIONARY['TRK']['norm']).T.ravel()
             x_map = self.x / np.hstack( (norm1,norm2,norm3) )
             x = self.x / np.hstack( (norm1*norm_fib,norm2,norm3) )


### PR DESCRIPTION
Fixed order of repetitions for each kernels. 

Checked that the norm of the matrix A generated with '`doNormalizeKernels' = False`
```
norm_A1 = np.linalg.norm(A,axis=0)`
```
is approximately equal to the norm calculate by COMMIT generate with '`doNormalizeKernels' = True`
  
```
norm1 = np.repeat(mit.KERNELS['wmr_norm'],nF)
norm2 = np.repeat(mit.KERNELS['wmh_norm'],nE)
norm3 = np.repeat(mit.KERNELS['iso_norm'],nV)
norm_fib = np.kron(np.ones(mit.KERNELS['wmr'].shape[0]), mit.DICTIONARY['TRK']['norm'])

norm_A2 =  np.hstack( (norm1*norm_fib,norm2,norm3) )
```

**norm_A1 ≈  norm_A2**
