### PR TITLE
Allow using datasets bigger than 256x256x256

### DIFF
--- a/commit/core.py
+++ b/commit/core.py
@@ -322,9 +322,9 @@ class Evaluation :
 
         self.DICTIONARY['IC']['n'] = self.DICTIONARY['IC']['fiber'].size
 
-        vx = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_IC_vx.dict'), dtype=np.uint8 ).astype(np.uint32)
-        vy = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_IC_vy.dict'), dtype=np.uint8 ).astype(np.uint32)
-        vz = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_IC_vz.dict'), dtype=np.uint8 ).astype(np.uint32)
+        vx = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_IC_vx.dict'), dtype=np.uint16 ).astype(np.uint32)
+        vy = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_IC_vy.dict'), dtype=np.uint16 ).astype(np.uint32)
+        vz = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_IC_vz.dict'), dtype=np.uint16 ).astype(np.uint32)
         self.DICTIONARY['IC']['v'] = vx + self.get_config('dim')[0] * ( vy + self.get_config('dim')[1] * vz )
         del vx, vy, vz
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -108,7 +108,7 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
     print '\t\t\t- %d x %d x %d' % ( Nx, Ny, Nz )
     print '\t\t\t- %.4f x %.4f x %.4f' % ( Px, Py, Pz )
     print '\t\t\t- %d fibers' % trk_hdr['n_count']
-    if Nx > 255 or Nz > 255 or Nz > 255 :
+    if Nx >= 2**16 or Nz >= 2**16 or Nz >= 2**16 :
         raise RuntimeError( 'The max dim size is 2^16 voxels' )
 
     # white-matter mask

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -67,7 +67,7 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
         If True then generate a .trk file in the 'path_out' containing the fibers used in the dictionary (default : True)
     """
 
-    # check conflicts of fiber_shift       
+    # check conflicts of fiber_shift
     if np.isscalar(fiber_shift) :
         fiber_shiftX = fiber_shift
         fiber_shiftY = fiber_shift
@@ -108,6 +108,8 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
     print '\t\t\t- %d x %d x %d' % ( Nx, Ny, Nz )
     print '\t\t\t- %.4f x %.4f x %.4f' % ( Px, Py, Pz )
     print '\t\t\t- %d fibers' % trk_hdr['n_count']
+    if Nx > 255 or Nz > 255 or Nz > 255 :
+        raise RuntimeError( 'The max dim size is 2^16 voxels' )
 
     # white-matter mask
     cdef float* ptrMASK
@@ -180,7 +182,7 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
         file_kept = np.fromfile( join(path_out,'dictionary_TRK_kept.dict'), dtype=np.bool_ )
         ind = 0
         for f in fib:
-            if file_kept[ind]: 
+            if file_kept[ind]:
                 fibKept.append( (f[0],None, None) )
             ind = ind+1
         nibabel.trackvis.write( join(path_out,'dictionary_TRK_fibers.trk'), fibKept, trk_hdr )

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -38,8 +38,8 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
 
     filename_mask : string
         Path to a binary mask to restrict the analysis to specific areas. Segments
-        outside this mask are discarded. If not specified, the mask is created from
-        all voxels crossed by tracts.
+        outside this mask are discarded. If not specified (default), the mask is created from
+        all voxels intersected by the tracts.
 
     do_intersect : boolean
         If True then fiber segments that intersect voxel boundaries are splitted (default).

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -190,9 +190,12 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
     print '   [ %.1f seconds ]' % ( time.time() - tic )
 
     # save TDI and MASK maps
-    affine = None
-    if filename_peaks is not None :
+    if filename_mask is not None :
+        affine = niiMASK.affine if nibabel.__version__ >= '2.0.0' else niiMASK.get_affine()
+    elif filename_peaks is not None :
         affine = niiPEAKS.affine if nibabel.__version__ >= '2.0.0' else niiPEAKS.get_affine()
+    else :
+        affine = np.diag( [Px, Py, Pz, 1] )
 
     niiTDI = nibabel.Nifti1Image( niiTDI_img, affine )
     nibabel.save( niiTDI, join(path_out,'dictionary_tdi.nii.gz') )

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -143,9 +143,9 @@ int trk2dictionary(
             for (it=FiberSegments.begin(); it!=FiberSegments.end(); it++)
             {
                 fwrite( &totFibers,      4, 1, pDict_IC_f );
-                fwrite( &(it->first.x),  1, 1, pDict_IC_vx );
-                fwrite( &(it->first.y),  1, 1, pDict_IC_vy );
-                fwrite( &(it->first.z),  1, 1, pDict_IC_vz );
+                fwrite( &(it->first.x),  2, 1, pDict_IC_vx );
+                fwrite( &(it->first.y),  2, 1, pDict_IC_vy );
+                fwrite( &(it->first.z),  2, 1, pDict_IC_vz );
                 fwrite( &(it->first.ox), 1, 1, pDict_IC_ox );
                 fwrite( &(it->first.oy), 1, 1, pDict_IC_oy );
                 fwrite( &(it->second),   4, 1, pDict_IC_len );

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -12,10 +12,11 @@
 class segKey
 {
     public:
-    unsigned char x, y, z, ox, oy;
+    unsigned short x, y, z;
+    unsigned char ox, oy;
     segKey(){}
 
-    void set(unsigned char _x, unsigned char _y, unsigned char _z, unsigned char _ox, unsigned char _oy)
+    void set(unsigned short _x, unsigned short _y, unsigned short _z, unsigned char _ox, unsigned char _oy)
     {
         x  = _x;
         y  = _y;
@@ -33,10 +34,10 @@ class segKey
 class segInVoxKey
 {
     public:
-    unsigned char x, y, z;
+    unsigned short x, y, z;
     segInVoxKey(){}
 
-    void set(unsigned char _x, unsigned char _y, unsigned char _z)
+    void set(unsigned short _x, unsigned short _y, unsigned short _z)
     {
         x  = _x;
         y  = _y;
@@ -138,7 +139,7 @@ int trk2dictionary(
         {
             // add segments to files
             fiberNorm = 0;
-			fiberLen = 0;
+            fiberLen = 0;
             for (it=FiberSegments.begin(); it!=FiberSegments.end(); it++)
             {
                 fwrite( &totFibers,      4, 1, pDict_IC_f );
@@ -151,7 +152,7 @@ int trk2dictionary(
                 ptrTDI[ it->first.z + dim.z * ( it->first.y + dim.y * it->first.x ) ] += it->second;
                 inVoxKey.set( it->first.x, it->first.y, it->first.z );
                 FiberNorm[inVoxKey] += it->second;
-				fiberLen += it->second;
+                fiberLen += it->second;
             }
             for (itNorm=FiberNorm.begin(); itNorm!=FiberNorm.end(); itNorm++)
             {
@@ -160,7 +161,7 @@ int trk2dictionary(
             fiberNorm = sqrt(fiberNorm);
             FiberNorm.clear();
             fwrite( &fiberNorm,  1, 4, pDict_TRK_norm ); // actual length considered in optimization
-			fwrite( &fiberLen,  1, 4, pDict_TRK_len );
+            fwrite( &fiberLen,  1, 4, pDict_TRK_len );
             totICSegments += FiberSegments.size();
             totFibers++;
             kept = 1;


### PR DESCRIPTION
Currently, the maximum allowed dataset size is 256 voxels in any direction; this modifications allows for bigger datasets, for example when working on ex-vivo data or resampled datasets.