### PR TITLE
Add fiber blurring

### DIFF
--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -120,13 +120,13 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
         smoothingWeights[i] = np.exp( -smoothingRadii[i]**2 / (2.0*smoothing_sigma**2) )
 
     if nSmoothingRadii == 1 :
-        print '\t* Smooth fibers = False'
+        print '\t* Not smooth fibers'
     else :
         print '\t* Smooth fibers :'
         print '\t\t- sigma = %.3f' % smoothing_sigma
         print '\t\t- radii =   [',
         for i in xrange( 1, smoothingRadii.size ) :
-            print '%.2f' % smoothingRadii[i],
+            print '%.3f' % smoothingRadii[i],
         print ']'
         print '\t\t- samples = [',
         for i in xrange( 1, smoothingSamples.size ) :

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -14,11 +14,16 @@ cdef extern from "trk2dictionary_c.cpp":
     int trk2dictionary(
         char* strTRKfilename, int Nx, int Ny, int Nz, float Px, float Py, float Pz, int n_count, int n_scalars, int n_properties, float fiber_shiftX, float fiber_shiftY, float fiber_shiftZ, int points_to_skip, float min_seg_len,
         float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int ECiz,
-        float* _ptrMASK, float* ptrTDI, char* path_out, int c, double* ptrAFFINE
+        float* _ptrMASK, float* ptrTDI, char* path_out, int c, double* ptrAFFINE,
+        int nSmoothingRadii, double smoothingSigma, double* ptrSmoothingRadii, int* ptrSmoothingSamples, double* ptrSmoothingWeights
     ) nogil
 
 
-cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, do_intersect = True, fiber_shift = 0, points_to_skip = 0, vf_THR = 0.1, peaks_use_affine = False, flip_peaks = [False,False,False], min_seg_len = 1e-3, gen_trk = True ):
+cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, do_intersect = True,
+    fiber_shift = 0, points_to_skip = 0, vf_THR = 0.1, peaks_use_affine = False,
+    flip_peaks = [False,False,False], min_seg_len = 1e-3, gen_trk = True,
+    smoothing_radii = [], smoothing_samples = [], smoothing_sigma = 1.0
+    ):
     """Perform the conversion of a tractoram to the sparse data-structure internally
     used by COMMIT to perform the matrix-vector multiplications with the operator A
     during the inversion of the linear system.
@@ -91,8 +96,55 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
     print '\t* Points to skip   = %d' % points_to_skip
     print '\t* Min segment len  = %.2e' % min_seg_len
 
+    # check smoothing params
+    cdef :
+        double [:] smoothingRadii
+        int [:] smoothingSamples
+        double [:] smoothingWeights
+        double* ptrSmoothingRadii
+        int* ptrSmoothingSamples
+        double* ptrSmoothingWeights
+        int nSmoothingRadii
+
+    if len(smoothing_radii) != len(smoothing_samples) :
+        raise RuntimeError( 'number of radii and samples must match' )
+
+    # convert to numpy arrays (add fake radius for original segment)
+    nSmoothingRadii = len(smoothing_radii)+1
+    smoothingRadii = np.array( [0.0]+smoothing_radii, np.double )
+    smoothingSamples = np.array( [1]+smoothing_samples, np.int32 )
+
+    # compute weights for gaussian damping
+    smoothingWeights = np.empty_like( smoothingRadii )
+    for i in xrange(nSmoothingRadii):
+        smoothingWeights[i] = np.exp( -smoothingRadii[i]**2 / (2.0*smoothing_sigma**2) )
+
+    if nSmoothingRadii == 1 :
+        print '\t* Smooth fibers = False'
+    else :
+        print '\t* Smooth fibers :'
+        print '\t\t- sigma = %.3f' % smoothing_sigma
+        print '\t\t- radii =   [',
+        for i in xrange( 1, smoothingRadii.size ) :
+            print '%.2f' % smoothingRadii[i],
+        print ']'
+        print '\t\t- samples = [',
+        for i in xrange( 1, smoothingSamples.size ) :
+            print '%5d' % smoothingSamples[i],
+        print ']'
+        print '\t\t- weights = [',
+        for i in xrange( 1, smoothingWeights.size ) :
+            print '%.3f' % smoothingWeights[i],
+        print ']'
+
+    ptrSmoothingRadii   = &smoothingRadii[0]
+    ptrSmoothingSamples = &smoothingSamples[0]
+    ptrSmoothingWeights = &smoothingWeights[0]
+
+    # minimum segment length
     if min_seg_len < 0 :
         raise RuntimeError( 'min_seg_len must be >= 0' )
+
 
     print '\t* Loading data:'
 
@@ -183,7 +235,8 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
         trk_hdr['voxel_size'][0], trk_hdr['voxel_size'][1], trk_hdr['voxel_size'][2],
         trk_hdr['n_count'], trk_hdr['n_scalars'], trk_hdr['n_properties'], fiber_shiftX, fiber_shiftY, fiber_shiftZ, points_to_skip, min_seg_len,
         ptrPEAKS, Np, vf_THR, -1 if flip_peaks[0] else 1, -1 if flip_peaks[1] else 1, -1 if flip_peaks[2] else 1,
-        ptrMASK, ptrTDI, path_out, 1 if do_intersect else 0, ptrAFFINE );
+        ptrMASK, ptrTDI, path_out, 1 if do_intersect else 0, ptrAFFINE,
+        nSmoothingRadii, smoothing_sigma, ptrSmoothingRadii, ptrSmoothingSamples, ptrSmoothingWeights );
     if ret == 0 :
         print '   [ DICTIONARY not generated ]'
         return None

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -69,10 +69,16 @@ cpdef run( filename_trk, path_out, filename_peaks = None, filename_mask = None, 
         If necessary, flips peak orientations along each axis (default : no flipping).
 
     min_seg_len : float
-        Discard segments <= than this length in mm (default : 1e-3 )
+        Discard segments <= than this length in mm (default : 1e-3)
 
     gen_trk : boolean
         If True then generate a .trk file in the 'path_out' containing the fibers used in the dictionary (default : True)
+    blur_radii : list of float
+        Translate each segment to given radii to assign a broader fiber contribution (default : [])
+    blur_samples : list of integer
+        Segments are duplicated along a circle at a given radius; this parameter controls the number of samples to take over a given circle (defaut : [])
+    blur_sigma
+        The contributions of the segments at different radii are damped as a Gaussian (default : 1.0)
     """
 
     # check conflicts of fiber_shift

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -81,7 +81,7 @@ int trk2dictionary(
     float fiber_shiftX, float fiber_shiftY, float fiber_shiftZ, int points_to_skip, float min_seg_len,
     float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int ECiz,
     float* _ptrMASK, float* ptrTDI, char* path_out, int c, double* ptrAFFINE,
-    int nSmoothingRadii, double smoothingSigma, double* ptrSmoothingRadii, int* ptrSmoothingSamples, double* ptrSmoothingWeights
+    int nBlurRadii, double blurSigma, double* ptrBlurRadii, int* ptrBlurSamples, double* ptrBlurWeights
 )
 {
     /*=========================*/
@@ -120,13 +120,13 @@ int trk2dictionary(
     radii.clear();
     sectors.clear();
     weights.clear();
-    for(int i=0; i<nSmoothingRadii ;i++)
+    for(int i=0; i<nBlurRadii ;i++)
     {
-        radii.push_back( ptrSmoothingRadii[i] );
-        sectors.push_back( ptrSmoothingSamples[i] );
-        weights.push_back( ptrSmoothingWeights[i] );
+        radii.push_back( ptrBlurRadii[i] );
+        sectors.push_back( ptrBlurSamples[i] );
+        weights.push_back( ptrBlurWeights[i] );
     }
-    radiusSigma = smoothingSigma;
+    radiusSigma = blurSigma;
 
     // open files
     filename = OUTPUT_path+"/dictionary_TRK_norm.dict";   FILE* pDict_TRK_norm = fopen(filename.c_str(),"wb");

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <string>
 #include <map>
+#include <vector>
 #include "Vector.h"
 #include "ProgressBar.h"
 
@@ -60,9 +61,15 @@ float           fiberShiftXmm, fiberShiftYmm, fiberShiftZmm;
 bool            doIntersect;
 float           minSegLen;
 
+std::vector<double> radii;         // radii for the extrusion
+std::vector<double> weights;       // damping weight
+std::vector<int>    sectors;       // number of duplicates across the extrusion circle
+double              radiusSigma;   // modulates the impact of each segment as function of radius
+
+
 bool rayBoxIntersection( Vector<double>& origin, Vector<double>& direction, Vector<double>& vmin, Vector<double>& vmax, double & t);
-void fiberForwardModel( float fiber[3][MAX_FIB_LEN], unsigned int pts );
-void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2 );
+void fiberForwardModel( float fiber[3][MAX_FIB_LEN], unsigned int pts, std::vector<int> sectors, std::vector<double> radii, std::vector<double> weight );
+void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2, double w );
 unsigned int read_fiber( FILE* fp, float fiber[3][MAX_FIB_LEN], int ns, int np );
 
 
@@ -70,9 +77,11 @@ unsigned int read_fiber( FILE* fp, float fiber[3][MAX_FIB_LEN], int ns, int np )
 // Function called by CYTHON
 // =========================
 int trk2dictionary(
-    char* strTRKfilename, int Nx, int Ny, int Nz, float Px, float Py, float Pz, int n_count, int n_scalars, int n_properties, 		float fiber_shiftX, float fiber_shiftY, float fiber_shiftZ, int points_to_skip, float min_seg_len,
+    char* strTRKfilename, int Nx, int Ny, int Nz, float Px, float Py, float Pz, int n_count, int n_scalars, int n_properties,
+    float fiber_shiftX, float fiber_shiftY, float fiber_shiftZ, int points_to_skip, float min_seg_len,
     float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int ECiz,
-    float* _ptrMASK, float* ptrTDI, char* path_out, int c, double* ptrAFFINE
+    float* _ptrMASK, float* ptrTDI, char* path_out, int c, double* ptrAFFINE,
+    int nSmoothingRadii, double smoothingSigma, double* ptrSmoothingRadii, int* ptrSmoothingSamples, double* ptrSmoothingWeights
 )
 {
     /*=========================*/
@@ -108,6 +117,17 @@ int trk2dictionary(
     doIntersect   = c > 0;
     minSegLen     = min_seg_len;
 
+    radii.clear();
+    sectors.clear();
+    weights.clear();
+    for(int i=0; i<nSmoothingRadii ;i++)
+    {
+        radii.push_back( ptrSmoothingRadii[i] );
+        sectors.push_back( ptrSmoothingSamples[i] );
+        weights.push_back( ptrSmoothingWeights[i] );
+    }
+    radiusSigma = smoothingSigma;
+
     // open files
     filename = OUTPUT_path+"/dictionary_TRK_norm.dict";   FILE* pDict_TRK_norm = fopen(filename.c_str(),"wb");
     if ( !pDict_TRK_norm )
@@ -132,7 +152,7 @@ int trk2dictionary(
     {
         PROGRESS.inc();
         N = read_fiber( fpTRK, fiber, n_scalars, n_properties );
-        fiberForwardModel( fiber, N );
+        fiberForwardModel( fiber, N, sectors, radii, weights );
 
         kept = 0;
         if ( FiberSegments.size() > 0 )
@@ -294,11 +314,11 @@ int trk2dictionary(
 /********************************************************************************************************************/
 /*                                                 fiberForwardModel                                                */
 /********************************************************************************************************************/
-void fiberForwardModel( float fiber[3][MAX_FIB_LEN], unsigned int pts )
+void fiberForwardModel( float fiber[3][MAX_FIB_LEN], unsigned int pts, std::vector<int> sectors, std::vector<double> radii, std::vector<double> weights )
 {
-    static Vector<double> S1, S2, S1m, S2m, P;
+    static Vector<double> S1, S2, S1m, S2m, P, q, n, qxn, qxqxn;
     static Vector<double> vox, vmin, vmax, dir;
-    static double         len, t;
+    static double         len, t, alpha, w, R;
     static int            i, j, k;
 
     FiberSegments.clear();
@@ -307,43 +327,89 @@ void fiberForwardModel( float fiber[3][MAX_FIB_LEN], unsigned int pts )
         // original segment to be processed
         S1.Set( fiber[0][i]   + fiberShiftXmm, fiber[1][i]   + fiberShiftYmm, fiber[2][i]   + fiberShiftZmm );
         S2.Set( fiber[0][i+1] + fiberShiftXmm, fiber[1][i+1] + fiberShiftYmm, fiber[2][i+1] + fiberShiftZmm );
-
-        // get a normal to the vector to move
         dir.x = S2.x-S1.x;
         dir.y = S2.y-S1.y;
         dir.z = S2.z-S1.z;
         dir.Normalize();
-        if ( doIntersect==false )
-            segmentForwardModel( S1, S2 );
-        else
-            while( 1 )
+
+        // get a normal to the vector to move
+        n.x = dir.y-dir.z;
+        n.y = dir.z-dir.x;
+        n.z = dir.x-dir.y;
+        n.Normalize();
+
+        /* assign contribution(s) */
+        for(k=0; k<(int)radii.size() ;k++)
+        {
+            if ( weights[k] < 1e-3 )
+                continue;
+
+            R = radii[k];
+
+            // quaternion (q.x, q.y, q.z, w) for rotation
+            alpha = 2.0*M_PI/sectors[k];
+            w = sin(alpha/2.0);
+            q.x = dir.x * w;
+            q.y = dir.y * w;
+            q.z = dir.z * w;
+            w = cos(alpha/2.0);
+
+
+            for(j=0; j<sectors[k] ;j++)
             {
-                len = sqrt( pow(S2.x-S1.x,2) + pow(S2.y-S1.y,2) + pow(S2.z-S1.z,2) ); // in mm
-                if ( len <= minSegLen )
-                    break;
+                // rotate the segment's normal
+                qxn.x = 2.0 * ( q.y * n.z - q.z * n.y );
+                qxn.y = 2.0 * ( q.z * n.x - q.x * n.z );
+                qxn.z = 2.0 * ( q.x * n.y - q.y * n.x );
+                qxqxn.x = q.y * qxn.z - q.z * qxn.y;
+                qxqxn.y = q.z * qxn.x - q.x * qxn.z;
+                qxqxn.z = q.x * qxn.y - q.y * qxn.x;
+                n.x += w * qxn.x + qxqxn.x;
+                n.y += w * qxn.y + qxqxn.y;
+                n.z += w * qxn.z + qxqxn.z;
+                // n /= np.linalg.norm(n)
 
-                // compute AABB of the first point (in mm)
-                vmin.x = floor( (S1.x + 1e-6*dir.x)/pixdim.x ) * pixdim.x;
-                vmin.y = floor( (S1.y + 1e-6*dir.y)/pixdim.y ) * pixdim.y;
-                vmin.z = floor( (S1.z + 1e-6*dir.z)/pixdim.z ) * pixdim.z;
-                vmax.x = vmin.x + pixdim.x;
-                vmax.y = vmin.y + pixdim.y;
-                vmax.z = vmin.z + pixdim.z;
+                // move the segment
+                S1m.x = S1.x + R*n.x;
+                S1m.y = S1.y + R*n.y;
+                S1m.z = S1.z + R*n.z;
+                S2m.x = S2.x + R*n.x;
+                S2m.y = S2.y + R*n.y;
+                S2m.z = S2.z + R*n.z;
 
-                if ( rayBoxIntersection( S1, dir, vmin, vmax, t ) && t>0 && t<len )
-                {
-                    // add the portion S1P, and then reiterate
-                    P.Set( S1.x + t*dir.x, S1.y + t*dir.y, S1.z + t*dir.z );
-                    segmentForwardModel( S1, P );
-                    S1.Set( P.x, P.y, P.z );
-                }
+                if ( doIntersect==false )
+                    segmentForwardModel( S1m, S2m, weights[k] );
                 else
-                {
-                    // add the segment S1S2 and stop iterating
-                    segmentForwardModel( S1, S2 );
-                    break;
-                }
+                    while( 1 )
+                    {
+                        len = sqrt( pow(S2m.x-S1m.x,2) + pow(S2m.y-S1m.y,2) + pow(S2m.z-S1m.z,2) ); // in mm
+                        if ( len <= minSegLen )
+                            break;
+
+                        // compute AABB of the first point (in mm)
+                        vmin.x = floor( (S1m.x + 1e-6*dir.x)/pixdim.x ) * pixdim.x;
+                        vmin.y = floor( (S1m.y + 1e-6*dir.y)/pixdim.y ) * pixdim.y;
+                        vmin.z = floor( (S1m.z + 1e-6*dir.z)/pixdim.z ) * pixdim.z;
+                        vmax.x = vmin.x + pixdim.x;
+                        vmax.y = vmin.y + pixdim.y;
+                        vmax.z = vmin.z + pixdim.z;
+
+                        if ( rayBoxIntersection( S1m, dir, vmin, vmax, t ) && t>0 && t<len )
+                        {
+                            // add the portion S1P, and then reiterate
+                            P.Set( S1m.x + t*dir.x, S1m.y + t*dir.y, S1m.z + t*dir.z );
+                            segmentForwardModel( S1m, P, weights[k] );
+                            S1m.Set( P.x, P.y, P.z );
+                        }
+                        else
+                        {
+                            // add the segment S1S2 and stop iterating
+                            segmentForwardModel( S1m, S2m, weights[k] );
+                            break;
+                        }
+                    }
             }
+        }
     }
 }
 
@@ -351,7 +417,7 @@ void fiberForwardModel( float fiber[3][MAX_FIB_LEN], unsigned int pts )
 /********************************************************************************************************************/
 /*                                                segmentForwardModel                                               */
 /********************************************************************************************************************/
-void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2 )
+void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2, double w )
 {
     static Vector<int>    vox;
     static Vector<double> dir, dirTrue;
@@ -391,7 +457,7 @@ void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2 )
     longitude  = atan2(dir.y, dir.x);
     colatitude = atan2( sqrt(dir.x*dir.x + dir.y*dir.y), dir.z );
     key.set( vox.x, vox.y, vox.z, (int)round(colatitude/M_PI*180.0), (int)round(longitude/M_PI*180.0) );
-    FiberSegments[key] += len;
+    FiberSegments[key] += w * len;
 }
 
 


### PR DESCRIPTION
Introduces the possibility to blur the contributions of the streamlines to the voxels when these are determined with `trk2dictionary`.
Three parameters are added:
- `blur_radii`: determines the distance from the main streamline of the blurring in mm (default : [])
- `blur_samples`: how many sectors to sample perpendicularly to the main streamlines (default : [])
- `blur_sigma`: each contribution is damped as a Gaussian (default : 1.0)

NB: of course this procedures introduces many more segments to be evaluated during the optimization (the number of unknown, i.e. x, is unaltered), so the fit will take more time.

