### PR TITLE
changed required privileges on the input tractogram in trk2dictionary

### DIFF
--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -103,7 +103,7 @@ int trk2dictionary(
 
     printf( "\t* Exporting IC compartments:\n" );
 
-    FILE* fpTRK = fopen(strTRKfilename,"r+b");
+    FILE* fpTRK = fopen(strTRKfilename,"rb");
     if (fpTRK == NULL) return 0;
     fseek(fpTRK,1000,SEEK_SET);
 


### PR DESCRIPTION
This lets you run trk2dictionary also on .trk files for which you have only reading privileges.