### PR TITLE
add details opt and txt file weights, no conflicts

### DIFF
--- a/commit/solvers.py
+++ b/commit/solvers.py
@@ -52,6 +52,7 @@ def nnls( y, A, At = None, tol_fun = 1e-4, tol_x = 1e-9, max_iter = 100, verbose
     E-mail: rafael.carrillo@epfl.ch
     """
     # Initialization
+    CONFIG = {}
     if At is None :
         At = A.T
 
@@ -153,5 +154,13 @@ def nnls( y, A, At = None, tol_fun = 1e-4, tol_x = 1e-9, max_iter = 100, verbose
 
     if verbose >= 1 :
         print "< Stopping criterion: %s >" % criterion
+
+    CONFIG['||Ax-y||'] = round(np.sqrt(2.0*curr_obj), 5)
+    CONFIG['Cost function'] = round(curr_obj, 5)
+    CONFIG['Abs error'] = round(abs_obj, 5)
+    CONFIG['Rel error'] = round(rel_obj, 5)
+    CONFIG['Abs x'] = round(abs_x, 5)
+    CONFIG['Rel x'] = round(rel_x, 5)
+    CONFIG['iteration'] = iter
 
     return x

--- a/commit/solvers.py
+++ b/commit/solvers.py
@@ -163,4 +163,4 @@ def nnls( y, A, At = None, tol_fun = 1e-4, tol_x = 1e-9, max_iter = 100, verbose
     CONFIG['Rel x'] = round(rel_x, 5)
     CONFIG['iteration'] = iter
 
-    return x
+    return x, CONFIG


### PR DESCRIPTION
Add details optimization in the "results.picke" file. #33 
Add ".txt" file with the output of the weights of COMMIT. The weights consider IC + EC + ISO.

The previous branch #34 was created from barakovic:master that was in conflict with daducci:master.
With this new branch there is a clean version of the branch from daducci:master.

This is not solving @matteofrigo suggestion to have multiple value of weights for each streamline.
This is not solving @sdeslauriers suggestion to have the "results" file in ".json". 