### PR TITLE
Fix segfault when using new regularization scheme

### DIFF
--- a/commit/proximals.pyx
+++ b/commit/proximals.pyx
@@ -53,7 +53,7 @@ cpdef projection_onto_l2_ball(np.ndarray[np.float64_t] x, double lam, int compar
         np.ndarray[np.float64_t] v
         size_t i
     v = x.copy()
-    xn = sqrt(sum(v[compartment_start:(compartment_start+compartment_size)]**2))
+    xn = sqrt(sum(v[compartment_start:compartment_start+compartment_size]**2))
     if xn > lam:
         for i in range(compartment_start, compartment_start+compartment_size):
             v[i] = v[i]/xn*lam

--- a/commit/proximals.pyx
+++ b/commit/proximals.pyx
@@ -66,17 +66,14 @@ cpdef omega_group_sparsity(np.ndarray[np.float64_t] v, np.ndarray[object] subtre
     """
     cdef:
         int nG = weight.size
-        size_t k, i
-        double xn, tmp = 0.0
+        size_t k
+        double tmp = 0.0
 
     if lam != 0:
         if n == 2:
             for k in range(nG):
                 idx = subtree[k]
-                xn = 0.0
-                for i in idx:
-                    xn += v[i]*v[i]
-                    tmp += weight[k] * sqrt( xn )
+                tmp += weight[k] * sqrt( sum(v[idx]**2) )
         elif n == np.Inf:
             for k in range(nG):
                 idx = subtree[k]
@@ -92,7 +89,7 @@ cpdef prox_group_sparsity( np.ndarray[np.float64_t] x, np.ndarray[object] subtre
         np.ndarray[np.float64_t] v
         int nG = weight.size, N, rho
         size_t k, i
-        double r, xn, theta
+        double r, xn
 
     v = x.copy()
     v[v<0] = 0.0
@@ -111,10 +108,7 @@ cpdef prox_group_sparsity( np.ndarray[np.float64_t] x, np.ndarray[object] subtre
         if n == 2:
             for k in range(nG):
                 idx = subtree[k]
-                xn = 0.0
-                for i in idx:
-                    xn += v[i]*v[i]
-                    xn = sqrt(xn)
+                xn = sqrt( sum(v[idx]**2) )
                 r = weight[k] * lam
                 if xn > r:
                     r = (xn-r)/xn

--- a/commit/proximals.pyx
+++ b/commit/proximals.pyx
@@ -1,3 +1,5 @@
+#!python
+#cython: boundscheck=False, wraparound=False
 """
 Author: Matteo Frigo - lts5 @ EPFL and Dep. of CS @ Univ. of Verona
 
@@ -10,9 +12,6 @@ cimport numpy as np
 from math import sqrt
 import sys
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.profile(False)
 
 cpdef non_negativity(np.ndarray[np.float64_t] x, int compartment_start, int compartment_size):
     """
@@ -26,6 +25,7 @@ cpdef non_negativity(np.ndarray[np.float64_t] x, int compartment_start, int comp
         if v[i] < 0.0:
             v[i] = 0.0
     return v
+
 
 cpdef soft_thresholding(np.ndarray[np.float64_t] x, double lam, int compartment_start, int compartment_size) :
     """
@@ -43,6 +43,7 @@ cpdef soft_thresholding(np.ndarray[np.float64_t] x, double lam, int compartment_
             v[i] -= lam
     return v
 
+
 cpdef projection_onto_l2_ball(np.ndarray[np.float64_t] x, double lam, int compartment_start, int compartment_size) :
     """
     Proximal of L2 norm
@@ -58,6 +59,7 @@ cpdef projection_onto_l2_ball(np.ndarray[np.float64_t] x, double lam, int compar
         for i in range(compartment_start, compartment_start+compartment_size):
             v[i] = v[i]/xn*lam
     return v
+
 
 cpdef omega_group_sparsity(np.ndarray[np.float64_t] v, np.ndarray[object] subtree, np.ndarray[np.float64_t] weight, double lam, double n) :
     """
@@ -80,6 +82,7 @@ cpdef omega_group_sparsity(np.ndarray[np.float64_t] v, np.ndarray[object] subtre
                 tmp += weight[k] * max( v[idx] )
     return lam*tmp
 
+
 cpdef prox_group_sparsity( np.ndarray[np.float64_t] x, np.ndarray[object] subtree, np.ndarray[np.float64_t] weight, double lam, double n ) :
     """
     References:
@@ -87,7 +90,7 @@ cpdef prox_group_sparsity( np.ndarray[np.float64_t] x, np.ndarray[object] subtre
     """
     cdef:
         np.ndarray[np.float64_t] v
-        int nG = weight.size, N, rho
+        int nG = weight.size
         size_t k, i
         double r, xn
 

--- a/commit/proximals.pyx
+++ b/commit/proximals.pyx
@@ -22,7 +22,7 @@ cpdef non_negativity(np.ndarray[np.float64_t] x, int compartment_start, int comp
         np.ndarray[np.float64_t] v
         size_t i
     v = x.copy()
-    for i in range(compartment_start, compartment_size):
+    for i in range(compartment_start, compartment_start+compartment_size):
         if v[i] < 0.0:
             v[i] = 0.0
     return v
@@ -36,7 +36,7 @@ cpdef soft_thresholding(np.ndarray[np.float64_t] x, double lam, int compartment_
         np.ndarray[np.float64_t] v
         size_t i
     v = x.copy()
-    for i in range(compartment_start, compartment_size):
+    for i in range(compartment_start, compartment_start+compartment_size):
         if v[i] <= lam:
             v[i] = 0.0
         else:
@@ -53,9 +53,9 @@ cpdef projection_onto_l2_ball(np.ndarray[np.float64_t] x, double lam, int compar
         np.ndarray[np.float64_t] v
         size_t i
     v = x.copy()
-    xn = sqrt(sum(v[compartment_start:compartment_size]**2))
+    xn = sqrt(sum(v[compartment_start:(compartment_start+compartment_size)]**2))
     if xn > lam:
-        for i in range(compartment_start, compartment_size):
+        for i in range(compartment_start, compartment_start+compartment_size):
             v[i] = v[i]/xn*lam
     return v
 

--- a/commit/solvers.py
+++ b/commit/solvers.py
@@ -168,7 +168,7 @@ def regularisation2omegaprox(regularisation):
     sizeIC  = regularisation.get('sizeIC')
     if lambdaIC == 0.0:
         omegaIC = lambda x: 0.0
-        proxIC  = lambda x: non_negativity(x, startIC, sizeIC)
+        proxIC  = lambda x: x
     elif normIC == norm2:
         omegaIC = lambda x: lambdaIC * np.linalg.norm(x[startIC:sizeIC])
         proxIC  = lambda x: projection_onto_l2_ball(x, lambdaIC, startIC, sizeIC)
@@ -205,7 +205,7 @@ def regularisation2omegaprox(regularisation):
     sizeEC  = regularisation.get('sizeEC')
     if lambdaEC == 0.0:
         omegaEC = lambda x: 0.0
-        proxEC  = lambda x: non_negativity(x, startEC, sizeEC)
+        proxEC  = lambda x: x
     elif normEC == norm2:
         omegaEC = lambda x: lambdaEC * np.linalg.norm(x[startEC:sizeEC])
         proxEC  = lambda x: projection_onto_l2_ball(x, lambdaEC, startEC, sizeEC)
@@ -223,7 +223,7 @@ def regularisation2omegaprox(regularisation):
     sizeISO  = regularisation.get('sizeISO')
     if lambdaISO == 0.0:
         omegaISO = lambda x: 0.0
-        proxISO  = lambda x: non_negativity(x, startISO, sizeISO)
+        proxISO  = lambda x: x
     elif normISO == norm2:
         omegaISO = lambda x: lambdaISO * np.linalg.norm(x[startISO:sizeISO])
         proxISO  = lambda x: projection_onto_l2_ball(x, lambdaISO, startISO, sizeISO)


### PR DESCRIPTION
When using the new code (@matteofrigo ), sometimes (randomly) there is the following error:

> Python(80308,0x7fff8f699380) malloc: *** error for object 0x7ff19f64c400: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6

The main issue is that when there aren't EC or ISO compartments and the `lambda` for a given regularization is set to zero, the `non_negativity` prox was calculated in any case for these compartments even though there weren't such coefficients. This could lead to accessing bad memory locations and generate _segfaults_.