### PR TITLE
Temporary workaround for issue #54

### DIFF
--- a/commit/proximals.pyx
+++ b/commit/proximals.pyx
@@ -10,8 +10,6 @@ cimport cython
 import numpy as np
 cimport numpy as np
 from math import sqrt
-import sys
-
 
 cpdef non_negativity(np.ndarray[np.float64_t] x, int compartment_start, int compartment_size):
     """

--- a/commit/solvers.py
+++ b/commit/solvers.py
@@ -21,7 +21,7 @@ norm1 = 1
 norm2 = 2
 norminf = np.inf
 list_regnorms = [group_sparsity, non_negative, norm1, norm2]
-list_group_sparsity_norms = [norm2, norminf]
+list_group_sparsity_norms = [norm2]#, norminf] # removed because of issue #54
 
 def init_regularisation(commit_evaluation,
                         regnorms = (non_negative, non_negative, non_negative),


### PR DESCRIPTION
This PR is a workaround for the issue #54. The idea is to prevent the user to specify the Linf-norm in the regularizer of gNNLS.