### PR TITLE
Faster proxs and omegas

### DIFF
--- a/commit/proximals.pyx
+++ b/commit/proximals.pyx
@@ -24,7 +24,7 @@ cpdef non_negativity(double [::1] x, int compartment_start, int compartment_size
             v[i] = 0.0
         else :
             v[i] = x[i]
-    return v
+    return np.asarray( v )
 
 
 cpdef soft_thresholding(double [::1] x, double lam, int compartment_start, int compartment_size) :
@@ -40,7 +40,7 @@ cpdef soft_thresholding(double [::1] x, double lam, int compartment_start, int c
             v[i] = 0.0
         else:
             v[i] = x[i] - lam
-    return v
+    return np.asarray( v )
 
 
 cpdef projection_onto_l2_ball(double [::1] x, double lam, int compartment_start, int compartment_size) :
@@ -62,7 +62,7 @@ cpdef projection_onto_l2_ball(double [::1] x, double lam, int compartment_start,
     else :
         for i in xrange(compartment_start, compartment_start+compartment_size):
             v[i] = x[i]
-    return v
+    return np.asarray( v )
 
 
 cpdef omega_group_sparsity(double [::1] x, int [::1] group_idx, int [::1] group_size, double [::1] group_weight, double lam, double n) :
@@ -146,4 +146,4 @@ cpdef prox_group_sparsity( double [::1] x, int [::1] group_idx, int [::1] group_
         #                 v[i] = 0.0
         #             else :
         #                 v[i] -= r
-    return v
+    return np.asarray( v )

--- a/commit/proximals.pyx
+++ b/commit/proximals.pyx
@@ -1,5 +1,5 @@
 #!python
-#cython: boundscheck=False, wraparound=False
+#cython: boundscheck=False, wraparound=False, profile=False
 """
 Author: Matteo Frigo - lts5 @ EPFL and Dep. of CS @ Univ. of Verona
 
@@ -9,113 +9,141 @@ supported by the LTS5 laboratory at EPFL, Lausanne.
 cimport cython
 import numpy as np
 cimport numpy as np
-from math import sqrt
+from libc.math cimport sqrt
 
-cpdef non_negativity(np.ndarray[np.float64_t] x, int compartment_start, int compartment_size):
+
+cpdef non_negativity(double [::1] x, int compartment_start, int compartment_size):
     """
     POCS for the first orthant (non-negativity)
     """
     cdef:
-        np.ndarray[np.float64_t] v
-        size_t i
-    v = x.copy()
-    for i in range(compartment_start, compartment_start+compartment_size):
-        if v[i] < 0.0:
+        double [::1] v = np.empty_like( x )
+        int i
+    for i in xrange(compartment_start, compartment_start+compartment_size):
+        if x[i] <= 0.0 :
             v[i] = 0.0
+        else :
+            v[i] = x[i]
     return v
 
 
-cpdef soft_thresholding(np.ndarray[np.float64_t] x, double lam, int compartment_start, int compartment_size) :
+cpdef soft_thresholding(double [::1] x, double lam, int compartment_start, int compartment_size) :
     """
     Proximal of L1 norm
     """
     # NB: this preserves non-negativity
     cdef:
-        np.ndarray[np.float64_t] v
-        size_t i
-    v = x.copy()
-    for i in range(compartment_start, compartment_start+compartment_size):
-        if v[i] <= lam:
+        double [::1] v = np.empty_like( x )
+        int i
+    for i in xrange(compartment_start, compartment_start+compartment_size):
+        if x[i] <= lam:
             v[i] = 0.0
         else:
-            v[i] -= lam
+            v[i] = x[i] - lam
     return v
 
 
-cpdef projection_onto_l2_ball(np.ndarray[np.float64_t] x, double lam, int compartment_start, int compartment_size) :
+cpdef projection_onto_l2_ball(double [::1] x, double lam, int compartment_start, int compartment_size) :
     """
     Proximal of L2 norm
     """
     # NB: this preserves non-negativity
     cdef:
-        np.float64_t xn
-        np.ndarray[np.float64_t] v
-        size_t i
-    v = x.copy()
-    xn = sqrt(sum(v[compartment_start:compartment_start+compartment_size]**2))
-    if xn > lam:
-        for i in range(compartment_start, compartment_start+compartment_size):
-            v[i] = v[i]/xn*lam
+        double xn = 0.0, k
+        double [::1] v = np.empty_like( x )
+        int i
+    for i in xrange(compartment_start, compartment_start+compartment_size):
+        xn += x[i]*x[i]
+    xn = sqrt(xn)
+    if xn > lam :
+        k = lam/xn
+        for i in xrange(compartment_start, compartment_start+compartment_size):
+            v[i] = x[i]*k
+    else :
+        for i in xrange(compartment_start, compartment_start+compartment_size):
+            v[i] = x[i]
     return v
 
 
-cpdef omega_group_sparsity(np.ndarray[np.float64_t] v, np.ndarray[object] subtree, np.ndarray[np.float64_t] weight, double lam, double n) :
+cpdef omega_group_sparsity(double [::1] x, int [::1] group_idx, int [::1] group_size, double [::1] group_weight, double lam, double n) :
     """
     References:
         [1] Jenatton et al. - `Proximal Methods for Hierarchical Sparse Coding`
     """
     cdef:
-        int nG = weight.size
-        size_t k
-        double tmp = 0.0
+        int nG = group_size.size, N
+        int k, i, j = 0
+        double omega = 0.0, gNorm, x_i
 
     if lam != 0:
         if n == 2:
-            for k in range(nG):
-                idx = subtree[k]
-                tmp += weight[k] * sqrt( sum(v[idx]**2) )
-        elif n == np.Inf:
-            for k in range(nG):
-                idx = subtree[k]
-                tmp += weight[k] * max( v[idx] )
-    return lam*tmp
+            for k in xrange(nG):
+                N = group_size[k]
+                gNorm = 0.0
+                for i in xrange(j,j+N) :
+                    x_i = x[group_idx[i]]
+                    gNorm += x_i*x_i
+                omega += group_weight[k] * sqrt( gNorm )
+                j += N
+        elif n == np.inf:
+            for k in xrange(nG):
+                N = group_size[k]
+                gNorm = x[group_idx[j]]
+                for i in xrange(j+1,j+N) :
+                    x_i = x[group_idx[i]]
+                    if x_i > gNorm :
+                        gNorm = x_i
+                omega += group_weight[k] * gNorm
+                j += N
+    return lam*omega
 
 
-cpdef prox_group_sparsity( np.ndarray[np.float64_t] x, np.ndarray[object] subtree, np.ndarray[np.float64_t] weight, double lam, double n ) :
+cpdef prox_group_sparsity( double [::1] x, int [::1] group_idx, int [::1] group_size, double [::1] group_weight, double lam, double n ) :
     """
     References:
         [1] Jenatton et al. - `Proximal Methods for Hierarchical Sparse Coding`
     """
     cdef:
-        np.ndarray[np.float64_t] v
-        int nG = weight.size
-        size_t k, i
-        double r, xn
+        double [::1] v = np.empty_like( x )
+        int nG = group_size.size, N
+        int k, i, j = 0
+        double wl, gNorm, v_i
 
-    v = x.copy()
-    v[v<0] = 0.0
+    k = x.size
+    for i in xrange(k):
+        if x[i] <= 0.0:
+            v[i] = 0.0
+        else :
+            v[i] = x[i]
 
     if lam != 0:
-        if n == np.inf :
-            for k in range(nG) :
-                idx = subtree[k]
-                # xn = max( v[idx] )
-                r = weight[k] * lam
-                for i in idx :
-                    if v[i] <= r:
-                        v[i] = 0.0
-                    else :
-                        v[i] -= r
-        if n == 2:
-            for k in range(nG):
-                idx = subtree[k]
-                xn = sqrt( sum(v[idx]**2) )
-                r = weight[k] * lam
-                if xn > r:
-                    r = (xn-r)/xn
-                    for i in idx :
-                        v[i] *= r
-                else:
-                    for i in idx:
-                        v[i] = 0.0
+        if n == 2 :
+            for k in xrange(nG) :
+                N = group_size[k]
+                gNorm = 0.0
+                for i in xrange(j,j+N) :
+                    v_i = v[group_idx[i]]
+                    gNorm += v_i*v_i
+                gNorm = sqrt( gNorm )
+
+                wl = group_weight[k] * lam
+                if gNorm <= wl :
+                    for i in xrange(j,j+N) :
+                        v[ group_idx[i] ] = 0.0
+                else :
+                    wl = (gNorm-wl)/gNorm
+                    for i in xrange(j,j+N) :
+                        v[ group_idx[i] ] *= wl
+                j += N
+        # elif n == np.inf :
+        # [TODO] TO be correctly implemented
+        #     for k in range(nG) :
+        #         idx = subtree[k]
+        #         # xn = max( v[idx] )
+        #         r = weight[k] * lam
+        #         for i in idx :
+        #             if v[i] <= r:
+        #                 v[i] = 0.0
+        #             else :
+        #                 v[i] -= r
     return v

--- a/commit/solvers.py
+++ b/commit/solvers.py
@@ -176,7 +176,7 @@ def regularisation2omegaprox(regularisation):
 
         # convert to new data structure (needed for faster access)
         N = np.sum([g.size for g in structureIC])
-        groupIdxIC  = np.zeros( (N,), dtype=structureIC[0].dtype )
+        groupIdxIC  = np.zeros( (N,), dtype=np.int32 )
         groupSizeIC = np.zeros( (structureIC.size,), dtype=np.int32 )
         pos = 0
         for i, g in enumerate(structureIC) :

--- a/commit/solvers.py
+++ b/commit/solvers.py
@@ -26,7 +26,6 @@ list_group_sparsity_norms = [norm2]#, norminf] # removed because of issue #54
 def init_regularisation(commit_evaluation,
                         regnorms = (non_negative, non_negative, non_negative),
                         structureIC = None, weightsIC = None, group_norm = 2,
-                        group_is_ordered = False,
                         lambdas = (.0,.0,.0) ):
     """
     Initialise the data structure that defines Omega in
@@ -91,17 +90,6 @@ def init_regularisation(commit_evaluation,
             Default: group_norm = commit.solver.norm2
             To be chosen among commit.solver.{norm2,norminf}.
 
-    group_is_ordered - boolean :
-        True if the streamlines are ordered group-wise, False otherwise.
-            Defauls: False
-            This option is given for back compatibility with older and internal
-            version of the package that required an ordered version of the input
-            tractogram.
-            If you use QuickBundles(X) to define the group structure you
-            shouldn't take care of this option.
-
-            Note: this option will be deprecated in future release and gives a warning.
-
     lambdas - tuple :
         regularisation parameter for each compartment.
             Default: lambdas = (0.0, 0.0, 0.0)
@@ -131,7 +119,6 @@ def init_regularisation(commit_evaluation,
     regularisation['lambdaISO'] = float( lambdas[2] )
 
     # Solver-specific fields
-    regularisation['group_is_ordered'] = group_is_ordered  # This option will be deprecated in future release
     regularisation['structureIC']      = structureIC
     regularisation['weightsIC']        = weightsIC
     regularisation['group_norm']       = group_norm
@@ -181,13 +168,6 @@ def regularisation2omegaprox(regularisation):
     elif normIC == group_sparsity:
         weightsIC   = regularisation.get('weightsIC')
         structureIC = regularisation.get('structureIC')
-        if regularisation.get('group_is_ordered'): # This option will be deprecated in future release
-            warnings.warn('The ordered group structure will be deprecated. Check the documentation of commit.solvers.init_regularisation.',DeprecationWarning)
-            bundles = np.insert(structureIC,0,0)
-            structureIC = np.array([np.arange(sum(bundles[:k+1]),sum(bundles[:k+1])+bundles[k+1]) for k in range(len(bundles)-1)]) # check how it works with bundles=[2,5,4]
-            regularisation['structureIC'] = structureIC
-            regularisation['group_is_ordered'] = False # the group structure is overwritten, hence the flag has to be changed
-            del bundles
         if not len(structureIC) == len(weightsIC):
             raise ValueError('Number of groups and weights do not coincide.')
         group_norm = regularisation.get('group_norm')


### PR DESCRIPTION
This PR should be able to enable the following speed-up on the computation of omega and prox functions:
- about **450x** for `prox_group_sparsity` (from about 20.5 s to 48.2 ms)
- about **1400x** for `omega_group_sparsity` (from about 15.6 s to 11.2 ms)
The acceleration is achieved through a redesign of the data structure about the groups which allows a faster direct access to memory via `cython`.