### PR TITLE
Build operator in any folder

### DIFF
--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -8,7 +8,7 @@ cimport numpy as np
 import time
 import glob
 import sys
-from os import makedirs, remove
+from os import makedirs, remove, getcwd
 from os.path import exists, join as pjoin, isfile
 import nibabel
 import pickle
@@ -17,7 +17,7 @@ import commit.solvers
 import amico.scheme
 import amico.lut
 import pyximport
-pyximport.install( reload_support=True, language_level=3 )
+
 from amico.util import LOG, NOTE, WARNING, ERROR
 
 
@@ -629,7 +629,7 @@ cdef class Evaluation :
         LOG( '   [ %.1f seconds ]' % ( time.time() - tic ) )
 
 
-    def build_operator( self ) :
+    def build_operator( self, build_locally=False, build_dir=None ) :
         """Compile/build the operator for computing the matrix-vector multiplications by A and A'
         using the informations from self.DICTIONARY, self.KERNELS and self.THREADS.
         NB: needs to call this function to update pointers to data structures in case
@@ -657,6 +657,14 @@ cdef class Evaluation :
         config.nIC      = self.KERNELS['wmr'].shape[0]
         config.nEC      = self.KERNELS['wmh'].shape[0]
         config.nISO     = self.KERNELS['iso'].shape[0]
+
+        if build_locally:
+            if build_dir is None:
+                build_dir = getcwd()
+            pyximport.install( reload_support=True, language_level=3, build_in_temp=True, build_dir=build_dir, inplace=False )
+        else:
+            pyximport.install( reload_support=True, language_level=3 )
+
         if not 'commit.operator.operator' in sys.modules :
             import commit.operator.operator
         else :

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -629,7 +629,7 @@ cdef class Evaluation :
         LOG( '   [ %.1f seconds ]' % ( time.time() - tic ) )
 
 
-    def build_operator( self, build_locally=False, build_dir=None ) :
+    def build_operator( self, build_dir=None ) :
         """Compile/build the operator for computing the matrix-vector multiplications by A and A'
         using the informations from self.DICTIONARY, self.KERNELS and self.THREADS.
         NB: needs to call this function to update pointers to data structures in case
@@ -652,19 +652,17 @@ cdef class Evaluation :
 
         # need to pass these parameters at runtime for compiling the C code
         from commit.operator import config
-        config.nTHREADS = self.THREADS['n']
-        config.model    = self.model.id
-        config.nIC      = self.KERNELS['wmr'].shape[0]
-        config.nEC      = self.KERNELS['wmh'].shape[0]
-        config.nISO     = self.KERNELS['iso'].shape[0]
-        config.locally  = build_locally
+        config.nTHREADS   = self.THREADS['n']
+        config.model      = self.model.id
+        config.nIC        = self.KERNELS['wmr'].shape[0]
+        config.nEC        = self.KERNELS['wmh'].shape[0]
+        config.nISO       = self.KERNELS['iso'].shape[0]
+        config.build_dir  = build_dir
 
-        if build_locally:
-            if build_dir is None:
-                build_dir = getcwd()
+        if build_dir is not None:
             pyximport.install( reload_support=True, language_level=3, build_in_temp=True, build_dir=build_dir, inplace=False )
         else:
-            pyximport.install( reload_support=True, language_level=3)
+            pyximport.install( reload_support=True, language_level=3 )
 
         if not 'commit.operator.operator' in sys.modules :
             import commit.operator.operator

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -657,13 +657,14 @@ cdef class Evaluation :
         config.nIC      = self.KERNELS['wmr'].shape[0]
         config.nEC      = self.KERNELS['wmh'].shape[0]
         config.nISO     = self.KERNELS['iso'].shape[0]
+        config.locally  = build_locally
 
         if build_locally:
             if build_dir is None:
                 build_dir = getcwd()
             pyximport.install( reload_support=True, language_level=3, build_in_temp=True, build_dir=build_dir, inplace=False )
         else:
-            pyximport.install( reload_support=True, language_level=3 )
+            pyximport.install( reload_support=True, language_level=3)
 
         if not 'commit.operator.operator' in sys.modules :
             import commit.operator.operator

--- a/commit/operator/config.py
+++ b/commit/operator/config.py
@@ -1,5 +1,6 @@
-nTHREADS = None
-model    = None
-nIC      = None
-nEC      = None
-nISO     = None
+nTHREADS      = None
+model         = None
+nIC           = None
+nEC      	  = None
+nISO     	  = None
+build_locally = False

--- a/commit/operator/operator.pyxbld
+++ b/commit/operator/operator.pyxbld
@@ -27,7 +27,7 @@ def make_ext(modname, pyxfilename):
 
     path = dirname(pyxfilename)
 
-    if not config.locally:
+    if not config.build_dir is None:
         utime( join(path,filename), None)
 
     return Extension(name=modname,

--- a/commit/operator/operator.pyxbld
+++ b/commit/operator/operator.pyxbld
@@ -1,4 +1,5 @@
 import numpy
+from os import utime
 from os.path import dirname, join
 from setuptools import Extension
 
@@ -25,6 +26,10 @@ def make_ext(modname, pyxfilename):
         filename = "operator_withLUT.c"
 
     path = dirname(pyxfilename)
+
+    if not config.locally:
+        utime( join(path,filename), None)
+
     return Extension(name=modname,
                      sources=[pyxfilename, join(path, filename)],
                      include_dirs=[numpy.get_include()],

--- a/commit/operator/operator.pyxbld
+++ b/commit/operator/operator.pyxbld
@@ -1,34 +1,35 @@
 import numpy
-from os import utime
 from os.path import dirname, join
-from distutils.extension import Extension
+from setuptools import Extension
 
 # pass parameters to the compiler at runtime
 # [TODO] find a way to avoid using this fake module
 from commit.operator import config
 
+
 def make_ext(modname, pyxfilename):
 
-    if ( config.nTHREADS is None or config.nTHREADS < 1 or config.nTHREADS > 255 ):
-       raise RuntimeError( 'config.nTHREADS must be between 1 and 255' )
-    if ( config.nIC is None or config.nIC < 0 or config.nIC > 20 ):
-       raise RuntimeError( 'config.nIC must be in the range [0..20]' )
-    if ( config.nEC is None or config.nEC < 0 or config.nEC > 20 ):
-       raise RuntimeError( 'config.nEC must be in the range [0..20]' )
-    if ( config.nISO is None or config.nISO < 0 or config.nISO > 20 ):
-       raise RuntimeError( 'config.nISO must be in the range [0..20]' )
+    if (config.nTHREADS is None or config.nTHREADS < 1 or config.nTHREADS > 255):
+        raise RuntimeError('config.nTHREADS must be between 1 and 255')
+    if (config.nIC is None or config.nIC < 0 or config.nIC > 20):
+        raise RuntimeError('config.nIC must be in the range [0..20]')
+    if (config.nEC is None or config.nEC < 0 or config.nEC > 20):
+        raise RuntimeError('config.nEC must be in the range [0..20]')
+    if (config.nISO is None or config.nISO < 0 or config.nISO > 20):
+        raise RuntimeError('config.nISO must be in the range [0..20]')
 
     # Force recompilation
-    if config.model=="VolumeFractions" :
+    if config.model == "VolumeFractions":
         filename = "operator_noLUT.c"
-    else :
+    else:
         filename = "operator_withLUT.c"
 
     path = dirname(pyxfilename)
-    utime( join(path,filename), None)
     return Extension(name=modname,
-                     sources=[pyxfilename, join(path,filename)],
+                     sources=[pyxfilename, join(path, filename)],
                      include_dirs=[numpy.get_include()],
-                     define_macros = [('nTHREADS',config.nTHREADS), ('nIC',config.nIC), ('nEC',config.nEC), ('nISO',config.nISO)],
-                     extra_compile_args=['-w', '-O3', '-Ofast'],
-                     )
+                     define_macros=[('nTHREADS', config.nTHREADS),
+                                    ('nIC', config.nIC),
+                                    ('nEC', config.nEC),
+                                    ('nISO', config.nISO)],
+                     extra_compile_args=['-w', '-O3', '-Ofast'])

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class CustomBuildExtCommand(build_ext):
 
 description = 'Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT)'
 opts = dict(name='dmri-commit',
-            version='1.3.9',
+            version='1.3.9.1',
             description=description,
             long_description=description,
             author='Alessandro Daducci',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class CustomBuildExtCommand(build_ext):
 
 description = 'Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT)'
 opts = dict(name='dmri-commit',
-            version='1.3.9.1',
+            version='1.3.9.2',
             description=description,
             long_description=description,
             author='Alessandro Daducci',


### PR DESCRIPTION
No change in behavior, simply allows build_operator() to choose where to build the extension.

This makes the usage of singularity compatible with commit.