### PR TITLE
Store model parameters to results.pickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
+## [1.4.3] - 2020-10-22
+
+### Added
+- store model parameters to results.pickle
+
 ## [1.4.2] - 2020-10-22
 
 ### Fixed

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -247,6 +247,7 @@ cdef class Evaluation :
         # store some values for later use
         self.set_config('lmax', lmax)
         self.set_config('ndirs', ndirs)
+        self.set_config('model', self.model.get_params())
         self.model.scheme = self.scheme
 
         LOG( '\n-> Simulating with "%s" model:' % self.model.name )

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class CustomBuildExtCommand(build_ext):
 
 description = 'Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT)'
 opts = dict(name='dmri-commit',
-            version='1.4.2',
+            version='1.4.3',
             description=description,
             long_description=description,
             author='Alessandro Daducci',
@@ -54,7 +54,7 @@ opts = dict(name='dmri-commit',
             cmdclass={'build_ext': CustomBuildExtCommand},
             ext_modules=get_extensions(),
             setup_requires=['Cython>=0.29', 'numpy>=1.12'],
-            install_requires=['Cython>=0.29', 'dmri-amico>=1.2.3', 'dipy>=1.0', 'numpy>=1.12'],
+            install_requires=['Cython>=0.29', 'dmri-amico>=1.2.6', 'dipy>=1.0', 'numpy>=1.12'],
             package_data={'commit.operator': ["*.*"]})
 
 setup(**opts)


### PR DESCRIPTION
Adds the model-specific details of the adopted model, e.g. name, d_par, etc, inside the output results.pickle file. This additional feature requires the modifications made to AMICO in version 1.2.6.