### PR TITLE
Fix trk2dictionary affine bug for TCK tractograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
-## [1.4.5] - 2021-02-08
+## [1.4.5] - 2021-03-24
 
 ### Fixed
 - operator.pyxbld: Changed the condition to create a new operator
-- trk2dictionary.pyx: Check that the tractogram exists before trying to 
-            load it and remove the try section
-- trk2dictionary.run(): fixed bug with blur parameters and computing the blur
-
+- trk2dictionary.pyx: 
+    - Check that the tractogram exists before trying to load it and 
+        remove the try section
+    - Fixed bug with blur parameters and computing the blur
+    - Create dictionary\_mask.nii.gz and dictionary\_tdi.nii.gz with 
+        affine from TCK\_ref\_image for tck tractograms
+    
 ### Added
 - core.pyx: Add to the function build_operator the parameter build_dir
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -406,13 +406,18 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         return None
 
     # save TDI and MASK maps
-    if filename_mask is not None :
-        affine = niiMASK.affine if nibabel.__version__ >= '2.0.0' else niiMASK.get_affine()
-    elif filename_peaks is not None :
-        affine = niiPEAKS.affine if nibabel.__version__ >= '2.0.0' else niiPEAKS.get_affine()
-    else :
-        affine = np.diag( [Px, Py, Pz, 1] )
-
+    if extension == ".trk":
+        if filename_mask is not None :
+            affine = niiMASK.affine if nibabel.__version__ >= '2.0.0' else niiMASK.get_affine()
+        elif filename_peaks is not None :
+            affine = niiPEAKS.affine if nibabel.__version__ >= '2.0.0' else niiPEAKS.get_affine()
+        else :
+            affine = np.diag( [Px, Py, Pz, 1] )
+            WARNING( 'dictionary_mask.nii.gz and dictionary_tdi.nii.gz will be created with a default affine' )
+    
+    if extension == ".tck":
+        affine = nii_image.affine if nibabel.__version__ >= '2.0.0' else nii_image.get_affine()
+        
     niiTDI = nibabel.Nifti1Image( niiTDI_img, affine )
     nii_hdr = niiTDI.header if nibabel.__version__ >= '2.0.0' else niiTDI.get_header()
     nii_hdr['descrip'] = 'Created with COMMIT %s'%get_distribution('dmri-commit').version

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -407,13 +407,13 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
 
     # save TDI and MASK maps
     if extension == ".trk":
-        if filename_mask is not None :
-            affine = niiMASK.affine if nibabel.__version__ >= '2.0.0' else niiMASK.get_affine()
-        elif filename_peaks is not None :
+        if filename_peaks is not None :
             affine = niiPEAKS.affine if nibabel.__version__ >= '2.0.0' else niiPEAKS.get_affine()
+        elif filename_mask is not None :
+            affine = niiMASK.affine if nibabel.__version__ >= '2.0.0' else niiMASK.get_affine()        
         else :
             affine = np.diag( [Px, Py, Pz, 1] )
-            WARNING( 'dictionary_mask.nii.gz and dictionary_tdi.nii.gz will be created with a default affine' )
+            WARNING( 'Output maps will be created using a default affine, i.e., diagonal matrix [%0.2f, %0.2f, %0.2f, 1.]'%(Px, Py, Pz) )
     
     if extension == ".tck":
         affine = nii_image.affine if nibabel.__version__ >= '2.0.0' else nii_image.get_affine()


### PR DESCRIPTION
Create `dictionary_mask.nii.gz` and `dictionary_tdi.nii.gz` with affine from `TCK_ref_image` for TCK tractograms.

This PR fixes the problem for TCK tractograms.
In the case of TRK, the problem persists if a `mask` or `peaks` file is not specified.