### PR TITLE
Streamline weights in case of blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to COMMIT will be documented in this file.
 ## [1.4.6] - 2021-03-25
 
 ### Added
-- trk2dictionary: variable to keep track of streamline length (including blur)
+- Variable to keep track of total streamline contribution (including blur)
 
+### Fixed
+- Length of short segments to neglect
 
 ## [1.4.5] - 2021-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
+## [1.4.6] - 2021-03-25
+
+### Added
+- trk2dictionary: variable to keep track of streamline length (including blur)
+
+
 ## [1.4.5] - 2021-02-08
 
 ### Fixed
 - operator.pyxbld: Changed the condition to create a new operator
-- trk2dictionary.pyx: Check that the tractogram exists before trying to 
+- trk2dictionary.pyx: Check that the tractogram exists before trying to
             load it and remove the try section
 - trk2dictionary.run(): fixed bug with blur parameters and computing the blur
 
@@ -14,13 +20,13 @@ All notable changes to COMMIT will be documented in this file.
 - core.pyx: Add to the function build_operator the parameter build_dir
 
 ### Changed
-- core.pyx: The function build_operator checks if the LUT configuration 
+- core.pyx: The function build_operator checks if the LUT configuration
             changed before build a new operator
-- verbose variables in core.pyx and solvers.py changed to be boolean            
+- verbose variables in core.pyx and solvers.py changed to be boolean
 - trk2dictionary.run(): removed 'points_to_skip' option
 
 ## [1.4.4] - 2020-10-28
- 
+
 ### Changed
 - Option to set one single direction in the resolution of the LUT
 
@@ -119,7 +125,7 @@ All notable changes to COMMIT will be documented in this file.
 
 ### Added
 - Added possibility to save the predicted DW-MR signal in save_results.
- 
+
 ### Fixed
 - Minor cleanup.
 
@@ -128,7 +134,7 @@ All notable changes to COMMIT will be documented in this file.
 
 ### Added
 - Check if dictionary (upon loading) and data have the same geometry.
- 
+
 ### Fixed
 - Bug while saving coefficients in save_results.
 
@@ -142,12 +148,12 @@ All notable changes to COMMIT will be documented in this file.
 ## [1.3] - 2019-10-30
 
 This version of COMMIT *is not compatible* with [AMICO](https://github.com/daducci/AMICO) v1.0.1 of below. If you update COMMIT to this version, please update AMICO to version 1.1.0 or above.
- 
+
 ### Added
 - Changelog file to keep tracking of the COMMIT versions.
- 
+
 ### Changed
 - Added compatibility with low resolution LUTs.
- 
+
 ### Fixed
 - Nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@ All notable changes to COMMIT will be documented in this file.
 
 ## [1.4.6] - 2021-03-25
 
-### Added
-- Variable to keep track of total streamline contribution (including blur)
-
 ### Fixed
 - Length of short segments to neglect
+- Streamline weights, in case of blur, are properly scaled
 
 ## [1.4.5] - 2021-02-08
 

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -366,7 +366,7 @@ cdef class Evaluation :
         self.set_config('TRACKING_path', pjoin(self.get_config('DATA_path'),path))
 
         # check that ndirs of dictionary matches with that of the kernels
-        dictionary_info = load_dictionary_info( pjoin(self.get_config('TRACKING_path'), "dictionary_info.pickle") )
+        dictionary_info = load_dictionary_info( pjoin(self.get_config('TRACKING_path'), 'dictionary_info.pickle') )
         if dictionary_info['ndirs'] != self.get_config('ndirs'):
             ERROR( '"ndirs" of the dictionary (%d) does not match with the kernels (%d)' % (dictionary_info['ndirs'], self.get_config('ndirs')) )
         self.DICTIONARY['ndirs'] = dictionary_info['ndirs']
@@ -975,7 +975,15 @@ cdef class Evaluation :
             elif stat_coeffs == 'max' :
                 xic = np.max( xic, axis=0 )
             else :
-                ERROR( 'Stat not allowed. Possible values: sum, mean, median, min, max, all.', prefix='\n' )
+                ERROR( 'Stat not allowed. Possible values: sum, mean, median, min, max, all', prefix='\n' )
+
+        # scale output weights if blur was used
+        dictionary_info = load_dictionary_info( pjoin(self.get_config('TRACKING_path'), 'dictionary_info.pickle') )
+        if dictionary_info['blur_sigma'] > 0 :
+            if stat_coeffs == 'all' :
+                ERROR( 'Not yet implemented. Unable to account for blur in case of multiple streamline constributions.' )
+            xic = xic * self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
+            
         np.savetxt( pjoin(RESULTS_path,'streamline_weights.txt'), xic, fmt='%.5e' )
         self.set_config('stat_coeffs', stat_coeffs)
         print( '[ OK ]' )

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -24,7 +24,7 @@ from amico.util import LOG, NOTE, WARNING, ERROR
 
 def setup( lmax=12, ndirs=32761 ) :
     """General setup/initialization of the COMMIT framework.
-    
+
     Parameters
     ----------
     lmax : int
@@ -41,7 +41,7 @@ def setup( lmax=12, ndirs=32761 ) :
 
 def load_dictionary_info( filename ):
     """Function to load dictionary info file
-    
+
     Parameters
     ----------
     filename : string
@@ -353,7 +353,7 @@ cdef class Evaluation :
             Folder containing the output of the trk2dictionary script (relative to subject path)
         use_all_voxels_in_mask : boolean
             If False (default) the optimization will be conducted only on the voxels actually
-            traversed by tracts. If True, then all voxels present in the mask specified in 
+            traversed by tracts. If True, then all voxels present in the mask specified in
             trk2dictionary.run(), i.e. "filename_mask" parameter, will be used instead.
             NB: if no mask was specified in trk2dictionary, this parameter is irrelevant.
         """
@@ -395,10 +395,11 @@ cdef class Evaluation :
         sys.stdout.flush()
 
         self.DICTIONARY['TRK'] = {}
-        self.DICTIONARY['TRK']['kept']  = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_TRK_kept.dict'), dtype=np.uint8 )
-        self.DICTIONARY['TRK']['norm'] = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_TRK_norm.dict'), dtype=np.float32 )
-        self.DICTIONARY['TRK']['len']  = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_TRK_len.dict'), dtype=np.float32 )
-        
+        self.DICTIONARY['TRK']['kept']   = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_TRK_kept.dict'), dtype=np.uint8 )
+        self.DICTIONARY['TRK']['norm']   = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_TRK_norm.dict'), dtype=np.float32 )
+        self.DICTIONARY['TRK']['len']    = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_TRK_len.dict'), dtype=np.float32 )
+        self.DICTIONARY['TRK']['lenTot'] = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_TRK_lenTot.dict'), dtype=np.float32 )
+
 
         self.DICTIONARY['IC'] = {}
         self.DICTIONARY['IC']['fiber'] = np.fromfile( pjoin(self.get_config('TRACKING_path'),'dictionary_IC_f.dict'), dtype=np.uint32 )
@@ -416,7 +417,7 @@ cdef class Evaluation :
         self.DICTIONARY['IC']['len']   = self.DICTIONARY['IC']['len'][ idx ]
         del idx
 
-        # divide the length of each segment by the fiber length so that all the columns of the libear operator will have same length
+        # divide the length of each segment by the fiber length so that all the columns of the linear operator will have same length
         # NB: it works in conjunction with the normalization of the kernels
         cdef :
             np.float32_t [:] sl = self.DICTIONARY['IC']['len']
@@ -648,9 +649,9 @@ cdef class Evaluation :
         Parameters
         ----------
         build_dir : string
-            The folder in which to store the compiled files. 
+            The folder in which to store the compiled files.
             If None (default), they will end up in the .pyxbld directory in the user’s home directory.
-            If using this option, it is recommended to use a temporary directory, quit your python 
+            If using this option, it is recommended to use a temporary directory, quit your python
                 console between each build, and delete the content of the temporary directory.
         """
         if self.DICTIONARY is None :
@@ -659,7 +660,7 @@ cdef class Evaluation :
             ERROR( 'Response functions not generated; call "generate_kernels()" and "load_kernels()" first' )
         if self.THREADS is None :
             ERROR( 'Threads not set; call "set_threads()" first' )
-        
+
         if self.DICTIONARY['IC']['nF'] <= 0 :
             ERROR( 'No streamline found in the dictionary; check your data' )
         if self.DICTIONARY['EC']['nE'] <= 0 and self.KERNELS['wmh'].shape[0] > 0 :
@@ -672,21 +673,21 @@ cdef class Evaluation :
         from commit.operator import config
 
         compilation_is_needed = False
-        
+
         if config.nTHREADS is None or config.nTHREADS != self.THREADS['n']:
             compilation_is_needed = True
         if config.nIC is None or config.nIC != self.KERNELS['wmr'].shape[0]:
             compilation_is_needed = True
         if config.model is None or config.model != self.model.id:
-            compilation_is_needed = True        
+            compilation_is_needed = True
         if config.nEC is None or config.nEC != self.KERNELS['wmh'].shape[0]:
-            compilation_is_needed = True                
+            compilation_is_needed = True
         if config.nISO is None or config.nISO != self.KERNELS['iso'].shape[0]:
-            compilation_is_needed = True        
+            compilation_is_needed = True
         if config.build_dir != build_dir:
-            compilation_is_needed = True        
+            compilation_is_needed = True
 
-        if compilation_is_needed or not 'commit.operator.operator' in sys.modules :       
+        if compilation_is_needed or not 'commit.operator.operator' in sys.modules :
 
             if build_dir is not None:
                 if isdir(build_dir) and not len(listdir(build_dir)) == 0:
@@ -709,7 +710,7 @@ cdef class Evaluation :
                 import commit.operator.operator
             else :
                 reload( sys.modules['commit.operator.operator'] )
-            
+
         self.A = sys.modules['commit.operator.operator'].LinearOperator( self.DICTIONARY, self.KERNELS, self.THREADS )
 
         LOG( '   [ %.1f seconds ]' % ( time.time() - tic ) )
@@ -848,7 +849,7 @@ cdef class Evaluation :
 
         if save_opt_details is not None :
             WARNING('"save_opt_details" parameter is deprecated')
-        
+
         nF = self.DICTIONARY['IC']['nF']
         nE = self.DICTIONARY['EC']['nE']
         nV = self.DICTIONARY['nV']
@@ -996,5 +997,5 @@ cdef class Evaluation :
             nibabel.save( nibabel.Nifti1Image( self.niiDWI_img , affine ), pjoin(RESULTS_path,'fit_signal_estimated.nii.gz') )
             self.niiDWI_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ] = y_mea
             print( '[ OK ]' )
-        
+
         LOG( '   [ %.1f seconds ]' % ( time.time() - tic ) )

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -535,7 +535,7 @@ void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2, in
 
     // length of the segment
     len = dir.norm();
-    if ( len <= minSegLen )
+    if ( w*len <= minSegLen )
         return;
     dir.Normalize();
 
@@ -554,8 +554,8 @@ void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2, in
     ox = (int)round(colatitude/M_PI*180.0); // theta // i1
     oy = (int)round(longitude/M_PI*180.0);  // phi   // i2
     key.set( vox.x, vox.y, vox.z, (unsigned short) ptrHashTable[ox*181 + oy] );
-    FiberSegments[key] += w * len;
-    FiberLenTot += len;
+    FiberSegments[key] += w*len;
+    FiberLenTot += w*len;
     if ( k==0 ) // fiber length computed only from origianl segments
         FiberLen += len;
 }

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -556,7 +556,7 @@ void segmentForwardModel( const Vector<double>& P1, const Vector<double>& P2, in
     key.set( vox.x, vox.y, vox.z, (unsigned short) ptrHashTable[ox*181 + oy] );
     FiberSegments[key] += w*len;
     FiberLenTot += w*len;
-    if ( k==0 ) // fiber length computed only from origianl segments
+    if ( k==0 ) // fiber length computed only from original segments
         FiberLen += len;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class CustomBuildExtCommand(build_ext):
         # Now that the requirements are installed, get everything from numpy
         from Cython.Build import cythonize
         from numpy import get_include
-        
+
         # Add everything requires for build
         self.swig_opts = None
         self.include_dirs = [get_include()]
@@ -44,7 +44,7 @@ class CustomBuildExtCommand(build_ext):
 
 description = 'Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT)'
 opts = dict(name='dmri-commit',
-            version='1.4.5',
+            version='1.4.6',
             description=description,
             long_description=description,
             author='Alessandro Daducci',


### PR DESCRIPTION
In case of blur, i.e., when using the parameter `blur_sigma` in `trk2dictionary.run()`, the streamline weights returned in `streamline_weightx.txt` do not take into account the blur. This PR scales these values accordingly.