### PR TITLE
confidence_map from float64 to float32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
-## [1.5.0] - 2021-04-28
+## [1.5.0] - 2021-05-07
 
 ### Added
 - The possibility to specify a voxel confidence map
@@ -12,6 +12,7 @@ All notable changes to COMMIT will be documented in this file.
 
 ### Changed
 - Loading of nii data using (np.asanyarray( nii.dataobj )) in core and trk2dictionary
+- confidence_map from float64 to float32
 
 ## [1.4.6] - 2021-03-25
 

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -786,7 +786,7 @@ cdef class Evaluation :
             
             self.set_config('confidence_map_filename', confidence_map_filename)
             confidence_map  = nibabel.load( pjoin( self.get_config('DATA_path'), confidence_map_filename) )
-            self.confidence_map_img = np.asanyarray( confidence_map.dataobj ).astype(np.float64)
+            self.confidence_map_img = np.asanyarray( confidence_map.dataobj ).astype(np.float32)
 
             if self.confidence_map_img.ndim not in [3,4]:
                 ERROR( 'Confidence map must be 3D or 4D dataset' )
@@ -811,7 +811,7 @@ cdef class Evaluation :
             if (self.confidence_map_img.shape != self.niiDWI_img.shape):
                 ERROR( 'Dataset does not have the same geometry as the DWI signal' )
 
-            confidence_array = self.confidence_map_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ].flatten().astype(np.float64)
+            confidence_array = self.confidence_map_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ].flatten().astype(np.float32)
 
             if(np.isnan(confidence_array).any()): 
                 confidence_array[np.isnan(confidence_array)] = 0.
@@ -834,7 +834,7 @@ cdef class Evaluation :
             
             if(confidence_array_changed):
                 nV = self.DICTIONARY['nV']
-                self.confidence_map_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ] = np.reshape( confidence_array, (nV,-1) ).astype(np.float64)
+                self.confidence_map_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ] = np.reshape( confidence_array, (nV,-1) ).astype(np.float32)
 
         if x0 is not None :
             if x0.shape[0] != self.A.shape[1] :
@@ -988,7 +988,7 @@ cdef class Evaluation :
         print( '[ %.3f +/- %.3f ]' % ( tmp.mean(), tmp.std() ) )
         
         if self.confidence_map_img is not None:
-            confidence_array = np.reshape( self.confidence_map_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ].flatten().astype(np.float64), (nV,-1) ).astype(np.float32)
+            confidence_array = np.reshape( self.confidence_map_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ].flatten().astype(np.float32), (nV,-1) )
             
             print( '\t\t- RMSE considering the confidence map...  ', end='' )        
             sys.stdout.flush()
@@ -1015,6 +1015,7 @@ cdef class Evaluation :
             niiMAP_hdr['cal_max'] = 1
             nibabel.save( niiMAP, pjoin(RESULTS_path,'fit_NRMSE_adjusted.nii.gz') )
             print( '[ %.3f +/- %.3f ]' % ( tmp.mean(), tmp.std() ) )
+            confidence_array = None
 
         # Map of compartment contributions
         print( '\t* Voxelwise contributions:' )

--- a/commit/solvers.py
+++ b/commit/solvers.py
@@ -248,9 +248,9 @@ def solve(y, A, At, tol_fun = 1e-4, tol_x = 1e-6, max_iter = 1000, verbose = Tru
     """
     Solve the regularised least squares problem
 
-        argmin_x 0.5*||Ax-y||_2^2 + Omega(x)
+        argmin_x 0.5*|| sqrt(W) ( Ax-y ) ||_2^2 + Omega(x)
 
-    with the Omega described by 'regularisation'.
+    with the Omega described by 'regularisation' and W is the confidence_array
 
     Check the documentation of commit.solvers.init_regularisation to see how to
     solve a specific problem.
@@ -264,11 +264,13 @@ def solve(y, A, At, tol_fun = 1e-4, tol_x = 1e-6, max_iter = 1000, verbose = Tru
     if x0 is None:
         x0 = np.zeros(A.shape[1])
 
+    if confidence_array is not None:
+        confidence_array = np.sqrt(confidence_array)
    
     return fista( y, A, At, tol_fun, tol_x, max_iter, verbose, x0, omega, prox, confidence_array)
    
 
-def fista( y, A, At, tol_fun, tol_x, max_iter, verbose, x0, omega, proximal, confidence_array) :
+def fista( y, A, At, tol_fun, tol_x, max_iter, verbose, x0, omega, proximal, sqrt_W) :
     """
     Solve the regularised least squares problem
 
@@ -287,12 +289,10 @@ def fista( y, A, At, tol_fun, tol_x, max_iter, verbose, x0, omega, proximal, con
     # Initialization
     xhat = x0.copy()
     x = np.zeros_like(xhat)
-    if confidence_array is not None:
-        sqrt_W = np.sqrt(confidence_array)
+    if sqrt_W is not None:
         res = sqrt_W * (A.dot(xhat) - y) 
         grad = np.asarray(At.dot(sqrt_W * res))
     else:
-        sqrt_W = None
         res = A.dot(xhat) - y 
         grad = np.asarray(At.dot(res))
 


### PR DESCRIPTION
Changing the `confidence_map` from `float64` to `float32` to reduce the quantity of memory used. 