### PR TITLE
Save results format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
+## [1.5.3] - 2021-12-03
+
+### Added
+- Option 'coeffs_format' to 'save_results()'
+
 ## [1.5.2] - 2021-10-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to COMMIT will be documented in this file.
 ### Added
 - Option 'coeffs_format' to 'save_results()'
 
+### Changed
+- Install information are stored (and taken from) commit/info.py
+
 ## [1.5.2] - 2021-10-27
 
 ### Fixed

--- a/commit/__init__.py
+++ b/commit/__init__.py
@@ -1,5 +1,3 @@
-from .core import Evaluation
 __all__ = ['core','models','solvers','trk2dictionary']
-
-from pkg_resources import get_distribution
-__version__ = get_distribution('dmri-commit').version
+from .info import __version__
+from .core import Evaluation

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -901,7 +901,7 @@ cdef class Evaluation :
         return xic, xec, xiso
 
 
-    def save_results( self, path_suffix=None, coeffs_format='%.5e', stat_coeffs='sum', save_est_dwi=False, save_coeff=None, save_opt_details=None ) :
+    def save_results( self, path_suffix=None, coeffs_format='%.5e', stat_coeffs='sum', save_est_dwi=False ) :
         """Save the output (coefficients, errors, maps etc).
 
         Parameters
@@ -915,10 +915,6 @@ cdef class Evaluation :
             Format for saving the coefficients to `streamline_weights.txt` (default: '%.5e')
         save_est_dwi : boolean
             Save the estimated DW-MRI signal (default : False)
-        save_opt_details : boolean
-            DEPRECATED. The details of the optimization and the coefficients are always saved.
-        save_coeff : boolean
-            DEPRECATED. The estimated weights for the streamlines are always saved.
         """
         RESULTS_path = 'Results_' + self.model.id
         if path_suffix :
@@ -930,12 +926,6 @@ cdef class Evaluation :
 
         if self.x is None :
             ERROR( 'Model not fitted to the data; call "fit()" first' )
-
-        if save_coeff is not None :
-            WARNING('"save_coeff" parameter is deprecated')
-
-        if save_opt_details is not None :
-            WARNING('"save_opt_details" parameter is deprecated')
 
         nF = self.DICTIONARY['IC']['nF']
         nE = self.DICTIONARY['EC']['nE']

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -77,15 +77,15 @@ cdef class Evaluation :
     cdef public CONFIG
     cdef public confidence_map_img
     
-    def __init__( self, study_path, subject ) :
+    def __init__( self, study_path='.', subject='.' ) :
         """Setup the data structures with default values.
 
         Parameters
         ----------
         study_path : string
-            The path to the folder containing all the subjects from one study
+            The path to the folder containing all the subjects from one study (default : '.')
         subject : string
-            The path (relative to previous folder) to the subject folder
+            The path (relative to previous folder) to the subject folder (default : '.')
         """
         self.niiDWI             = None # set by "load_data" method
         self.scheme             = None # set by "load_data" method

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -901,7 +901,7 @@ cdef class Evaluation :
         return xic, xec, xiso
 
 
-    def save_results( self, path_suffix=None, stat_coeffs='sum', save_est_dwi=False, save_coeff=None, save_opt_details=None ) :
+    def save_results( self, path_suffix=None, coeffs_format='%.5e', stat_coeffs='sum', save_est_dwi=False, save_coeff=None, save_opt_details=None ) :
         """Save the output (coefficients, errors, maps etc).
 
         Parameters
@@ -911,6 +911,8 @@ cdef class Evaluation :
         stat_coeffs : string
             Stat to be used if more coefficients are estimated for each streamline.
             Options: 'sum', 'mean', 'median', 'min', 'max', 'all' (default : 'sum')
+        coeffs_format : string
+            Format for saving the coefficients to `streamline_weights.txt` (default: '%.5e')
         save_est_dwi : boolean
             Save the estimated DW-MRI signal (default : False)
         save_opt_details : boolean
@@ -1099,7 +1101,7 @@ cdef class Evaluation :
                 ERROR( 'Not yet implemented. Unable to account for blur in case of multiple streamline constributions.' )
             xic[ self.DICTIONARY['TRK']['kept']==1 ] *= self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
             
-        np.savetxt( pjoin(RESULTS_path,'streamline_weights.txt'), xic, fmt='%.5e' )
+        np.savetxt( pjoin(RESULTS_path,'streamline_weights.txt'), xic, fmt=coeffs_format )
         self.set_config('stat_coeffs', stat_coeffs)
         print( '[ OK ]' )
 

--- a/commit/info.py
+++ b/commit/info.py
@@ -1,0 +1,33 @@
+# -*- coding: UTF-8 -*-
+
+# Format version as expected by setup.py (string of form "X.Y.Z")
+_version_major = 1
+_version_minor = 5
+_version_micro = 3
+_version_extra = '' #'.dev'
+__version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
+
+NAME                = 'dmri-commit'
+DESCRIPTION         = 'Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT)'
+LONG_DESCRIPTION    = """
+========
+ COMMIT
+========
+
+The reconstructions recovered with existing tractography algorithms are not really quantitative even though diffusion MRI is a quantitative modality by nature. As a matter of fact, several techniques have been proposed in recent years to estimate, at the voxel level, intrinsic micro-structural features of the tissue, such as axonal density and diameter, by using multi-compartment models.
+Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT) implements a novel framework to re-establish the link between tractography and tissue micro-structure.
+
+Starting from an input set of candidate fiber-tracts, which can be estimated using standard fiber-tracking techniques, COMMIT models the diffusion MRI signal in each voxel of the image as a linear combination of the restricted and hindered contributions generated in every location of the brain by these candidate tracts. Then, COMMIT seeks for the effective contribution of each of them such that they globally fit the measured signal at best.
+
+These weights can be easily estimated by solving a convenient global convex optimization problem and using efficient algorithms. Results clearly demonstrated the benefits of the proposed formulation, opening new perspectives for a more quantitative and biologically-plausible assessment of the structural connectivity in the brain.
+"""
+URL                 = 'https://github.com/daducci/COMMIT'
+DOWNLOAD_URL        = "N/A"
+LICENSE             = 'BSD license'
+AUTHOR              = 'Alessandro Daducci'
+AUTHOR_EMAIL        = 'alessandro.daducci@univr.it'
+PLATFORMS           = "OS independent"
+MAJOR               = _version_major
+MINOR               = _version_minor
+MICRO               = _version_micro
+VERSION             = __version__

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class CustomBuildExtCommand(build_ext):
 
 description = 'Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT)'
 opts = dict(name='dmri-commit',
-            version='1.5.2',
+            version='1.5.3',
             description=description,
             long_description=description,
             author='Alessandro Daducci',

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,25 @@
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-
 def get_extensions():
     # Cython extension to create the sparse data structure from a tractogram
     # for the computation of matrix-vector multiplications
-    ext1 = Extension(name='commit.trk2dictionary',
+    trk2dictionary = Extension(name='commit.trk2dictionary',
                      sources=['commit/trk2dictionary/trk2dictionary.pyx'],
                      extra_compile_args=['-w'],
                      language='c++')
-
-    ext2 = Extension(name='commit.core',
+    core = Extension(name='commit.core',
                      sources=['commit/core.pyx'],
                      extra_compile_args=['-w'],
                      language='c++')
-
-    ext3 = Extension(name='commit.proximals',
+    proximals = Extension(name='commit.proximals',
                      sources=['commit/proximals.pyx'],
                      extra_compile_args=['-w'],
                      language='c++')
-
-    return [ext1, ext2, ext3]
-
+    return [trk2dictionary, core, proximals]
 
 class CustomBuildExtCommand(build_ext):
     """ build_ext command to use when numpy headers are needed. """
-
     def run(self):
         # Now that the requirements are installed, get everything from numpy
         from Cython.Build import cythonize
@@ -34,28 +28,31 @@ class CustomBuildExtCommand(build_ext):
         # Add everything requires for build
         self.swig_opts = None
         self.include_dirs = [get_include()]
-        self.distribution.ext_modules[:] = cythonize(
-                    self.distribution.ext_modules)
+        self.distribution.ext_modules[:] = cythonize(self.distribution.ext_modules)
 
         # Call original build_ext command
         build_ext.finalize_options(self)
         build_ext.run(self)
 
+# import details from commit/info.py
+import sys
+sys.path.insert(0, './commit/')
+import info
 
-description = 'Convex Optimization Modeling for Microstructure Informed Tractography (COMMIT)'
-opts = dict(name='dmri-commit',
-            version='1.5.3',
-            description=description,
-            long_description=description,
-            author='Alessandro Daducci',
-            author_email='alessandro.daducci@univr.it',
-            url='https://github.com/daducci/COMMIT',
-            license='BSD license',
-            packages=['commit', 'commit.operator'],
-            cmdclass={'build_ext': CustomBuildExtCommand},
-            ext_modules=get_extensions(),
-            setup_requires=['Cython>=0.29', 'numpy>=1.12'],
-            install_requires=['wheel', 'setuptools>=46.1', 'Cython>=0.29', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'dmri-amico>=1.3.0'],
-            package_data={'commit.operator': ["*.*"]})
-
-setup(**opts)
+# install the package
+setup(
+    name=info.NAME,
+    version=info.VERSION,
+    description=info.DESCRIPTION,
+    long_description=info.LONG_DESCRIPTION,
+    author=info.AUTHOR,
+    author_email=info.AUTHOR_EMAIL,
+    url=info.URL,
+    license=info.LICENSE,
+    packages=['commit', 'commit.operator'],
+    cmdclass={'build_ext': CustomBuildExtCommand},
+    ext_modules=get_extensions(),
+    setup_requires=['Cython>=0.29', 'numpy>=1.12'],
+    install_requires=['wheel', 'setuptools>=46.1', 'Cython>=0.29', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'dmri-amico>=1.3.0'],
+    package_data={'commit.operator': ["*.*"]}
+)


### PR DESCRIPTION
Allows the user to specify the string format when saving to `streamline_weights.txt` the estimated coefficients of the streamlines. this is done via the new parameter `coeffs_format` pf the `save_results()` function, and its default value is `%.5e` as it was before.