### PR TITLE
Data loading: check for "bad voxels" (NaN or Inf values) when load and pre-process data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
+## [1.6.3] - 2022-10-21
+
+### Added
+- 'replace_bad_voxels' parameter in 'load_data()' to replace NaN and Inf values in the signal
+
 ## [1.6.2] - 2022-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to COMMIT will be documented in this file.
 
 ## [1.6.3] - 2022-10-21
 
+### Changed
+- Ensure non-negative values in the 'y' vector before fit
+
 ### Added
 - 'replace_bad_voxels' parameter in 'load_data()' to replace NaN and Inf values in the signal
 

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -756,7 +756,10 @@ cdef class Evaluation :
             ERROR( 'Dictionary not loaded; call "load_dictionary()" first' )
         if self.niiDWI is None :
             ERROR( 'Data not loaded; call "load_data()" first' )
-        return self.niiDWI_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ].flatten().astype(np.float64)
+
+        y = self.niiDWI_img[ self.DICTIONARY['MASK_ix'], self.DICTIONARY['MASK_iy'], self.DICTIONARY['MASK_iz'], : ].flatten().astype(np.float64)
+        y[y < 0] = 0
+        return y
 
 
     def fit( self, tol_fun=1e-3, tol_x=1e-6, max_iter=100, verbose=True, x0=None, regularisation=None, confidence_map_filename=None, confidence_map_rescale=False ) :

--- a/commit/info.py
+++ b/commit/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 6
-_version_micro = 2
+_version_micro = 3
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 


### PR DESCRIPTION
Added:
- 'replace_bad_voxels' parameter in 'load_data()' to replace NaN and Inf values in the signal