### PR TITLE
v1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
+## [1.6.4] - 2023-02-14
+
+### Fixed
+- Invalid command 'bdist_wheel' error when install with pip<=20.0.2
+
 ## [1.6.3] - 2022-10-21
 
 ### Changed

--- a/commit/info.py
+++ b/commit/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 6
-_version_micro = 3
+_version_micro = 4
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     packages=['commit', 'commit.operator'],
     cmdclass={'build_ext': CustomBuildExtCommand},
     ext_modules=get_extensions(),
-    setup_requires=['Cython>=0.29', 'numpy>=1.12'],
-    install_requires=['wheel', 'setuptools>=46.1', 'Cython>=0.29', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'dmri-amico>=1.3.2'],
+    setup_requires=['Cython>=0.29', 'numpy>=1.12', 'wheel'],
+    install_requires=['setuptools>=46.1', 'Cython>=0.29', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'dmri-amico>=1.3.2'],
     package_data={'commit.operator': ["*.*"]}
 )


### PR DESCRIPTION
### Behaviour
Running `pip install dmri-commit` with `pip<=20.0.2` installs correctly the package, but this error message is shown:
```bash
Building wheel for dmri-commit (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/clori/commit_test/venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-_kxxkdl1/dmri-commit/setup.py'"'"'; __file__='"'"'/tmp/pip-install-_kxxkdl1/dmri-commit/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-h0imqbx2
       cwd: /tmp/pip-install-_kxxkdl1/dmri-commit/
  Complete output (8 lines):
  WARNING: The wheel package is not available.
  WARNING: The wheel package is not available.
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help

  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for dmri-commit
```
---
### Runtime info
OS: Ubuntu-20.04
Python: 3.8.10
pip: 20.0.2