### PR TITLE
[RELEASE] v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@
 - Switched to proprietary license (see `LICENSE` file)
 
 ### ✨Added
-- Added trk2dictionary.run() parameter `blur_clust_thr`
-- Implemented clustering in trk2dictionary
-- Added trk2dictionary.run() parallel computation
-- Added trk2dictionary.run() parameter `nthreads`
+- Added clustering in trk2dictionary.run()
+    * geometry-based clustering using `blur_clust_thr` parameter
+    * anatomical information streamlines clustering based on their endpoints using `blur_clust_groupby` parameter
+
+- Added trk2dictionary.run() parallel computation using `n_threads` parameter
+- Changed internal streamlines representation using `blur_core_extent` and `blur_gauss_extent` parameters
+- Added possibility to keep temporal files created by parallel trk2dictionary.run() and clustering using `keep_temp` parameter
 - Parallel compilation
 
 ### 🐛Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ _2023-03-21_
 - Added trk2dictionary.run() parameter `blur_clust_thr`
 - Implemented clustering in trk2dictionary
 - Added trk2dictionary.run() parallel computation
-- Added trk2dictionary.run() parameter `threads`
+- Added trk2dictionary.run() parameter `nthreads`
 - Parallel compilation
 
 ### Fixed 🐛

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,27 @@
-
 # Change Log
-All notable changes to COMMIT will be documented in this file.
+### All notable changes to `COMMIT` will be documented in this file.
 
-## `v2.0.0`
-_2023-03-21_
-
-### Changed 🛠️
+## `v2.0.0`<br>_2023-08-##_
+### 🛠️Changed
 - Default `ndirs=500` in `core.generate_kernels()` and in `trk2dictionary.run()`
 - Expire the deprecated `ndirs` parameter in `amico.core.setup()`
 - Expire the deprecated `filename_trk` and `gen_trk` parameters in `trk2dictionary.run()`
 - Removed unused parameter `ndirs` from `trk2dictionary_c.cpp()`
 - Build output goes into `build`
+- Switched to proprietary license (see `LICENSE` file)
 
-### Added ✨
+### ✨Added
 - Added trk2dictionary.run() parameter `blur_clust_thr`
 - Implemented clustering in trk2dictionary
 - Added trk2dictionary.run() parallel computation
 - Added trk2dictionary.run() parameter `nthreads`
 - Parallel compilation
 
-### Fixed 🐛
+### 🐛Fixed
 - Bugfixes
+
+---
+---
 
 ## [1.6.4] - 2023-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 ### All notable changes to `COMMIT` will be documented in this file.
 
-## `v2.0.0`<br>_2023-08-##_
+## `v2.0.0`<br>_2023-09-14_
 ### 🛠️Changed
 - Default `ndirs=500` in `core.generate_kernels()` and in `trk2dictionary.run()`
 - Expire the deprecated `ndirs` parameter in `amico.core.setup()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,23 @@
 # Change Log
 All notable changes to COMMIT will be documented in this file.
 
-## [2.0.0] - 2023-03-08
+## `v2.0.0`
+_2023-03-16_
 
-### Changed
+### Changed 🛠️
 - Default `ndirs=500` in `core.generate_kernels()` and in `trk2dictionary.run()`
 - Expire the deprecated `ndirs` parameter in `amico.core.setup()`
 - Expire the deprecated `filename_trk` and `gen_trk` parameters in `trk2dictionary.run()`
 - Removed unused parameter `ndirs` from `trk2dictionary_c.cpp()`
 
-### Added
+### Added ✨
 - Added trk2dictionary.run() parameter `blur_clust_thr`
 - Implemented clustering in trk2dictionary
 - Added trk2dictionary.run() parallel computation
 - Added trk2dictionary.run() parameter `threads`
+
+### Fixed 🐛
+- Bugfixes
 
 ## [1.6.4] - 2023-02-14
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,79 @@
-BSD 3-Clause License
+################################################################################
+                       COMMIT software license agreement
+                          Version 2.0.0, 24 July 2023
+################################################################################
 
-Copyright (c) 2021, COMMIT developers
-All rights reserved.
+------------------------------------PREAMBLE------------------------------------
+This license agreement (“Agreement”) is a legal agreement between you and the
+Diffusion Imaging and Connectivity Estimation laboratory (“DICE lab”) for the
+use of the COMMIT software (“Software”). By downloading and/or using the
+Software, you hereby accept and agree to all the terms and conditions of this
+Agreement. As used in this Agreement, “you” refers to any individual or
+organization that uses the Software.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
+------------------------------TERMS AND CONDITIONS------------------------------
+[1] License Grant
+Subject to all the terms and conditions of this Agreement, the DICE lab hereby
+grants you a worldwide, non-exclusive, non-transferable, limited license to
+copy, use, modify, and redistribute the Software solely for research and
+educational purposes, free of charge.
 
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+[2] Commercial use
+You may not use the Software and/or any work based on or using the Software for
+any commercial purpose, including but not limited to selling, licensing,
+distributing, renting, or leasing the Software for profit. If you want to use
+the Software for commercial purposes, you may contact the DICE lab to obtain a
+commercial license agreement. The DICE lab may consider offering a commercial
+license, subject to negotiation of appropriate terms and conditions, including
+but not limited to the payment of a license fee and compliance with any
+additional restriction on the use of the Software.
 
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
+[3] Attributions and Acknowledgments
+You agree to provide an acknowledgement identifying the Software and referencing
+its use in any publication, presentation, research result, and product related
+to or arising from the use of the Software. You also agree to give proper
+attribution to the original Software and reproduce this Agreement in any
+modified and/or redistributed work based on the Software.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+[4] Patents
+If you plan to file a patent application based on or using the Software, you
+must contact the DICE lab. The DICE lab may have certain rights or restrictions
+related to such patents that need to be addressed before filing the application.
+
+[5] Compliance with Law
+In exercising your rights under this Agreement, you agree to comply with all
+applicable governmental laws and regulations, including but not limited to the
+use, export, and transmission of the Software. You are solely responsible for
+ensuring that your use of the Software complies with such laws and regulations.
+The DICE lab is not responsible for any violations of such laws or regulations
+by you.
+
+[6] Warranty
+The Software is provided "AS IS" without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability, fitness
+for a particular purpose and non-infringement of third-party rights. The
+Software may also contain errors and is subject to further development and
+revision. The DICE lab does not guarantee the accuracy of the Software or any
+result or data arising from the use of the Software.
+
+[7] Disclaimers
+The Software has been designed for research purposes only and has not been
+reviewed or approved by the Food and Drug Administration or by any other agency.
+You acknowledge and agree that clinical applications are neither recommended nor
+advised.
+
+[8] Limitation of Liability
+In no event shall the DICE lab be liable to any party for any direct, indirect,
+special, incidental, exemplary, or consequential damages, however caused and
+under any theory of liability, arising in any way related to the Software, even
+if the DICE lab has been advised of the possibility of such damages. Except to
+the extent prohibited by law or regulation, you assume all risk and liability
+for your use of the Software. You also agree to indemnify and hold harmless the
+DICE lab from and against all claims, suits, actions, demands, and judgments
+arising from your use or misuse of the Software.
+
+
+------------------------------------CONTACT-------------------------------------
+If you have any question about the terms of this Agreement, you may contact the
+head of the DICE lab Alessandro Daducci at alessandro.daducci@univr.it

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -1116,7 +1116,7 @@ cdef class Evaluation :
         if dictionary_info['blur_gauss_extent'] > 0 or dictionary_info['blur_core_extent'] > 0 :
             if stat_coeffs == 'all' :
                 ERROR( 'Not yet implemented. Unable to account for blur in case of multiple streamline constributions.' )
-            if len( dictionary_info["tractogram_centr_idx"] ) > 0 :
+            if "tractogram_centr_idx" in dictionary_info.keys():
                 ordered_idx = dictionary_info["tractogram_centr_idx"].astype(np.int64)
                 unravel_weights = np.zeros( dictionary_info['n_count'], dtype=np.float64)
                 unravel_weights[ordered_idx] = self.DICTIONARY['TRK']['kept'].astype(np.float64)

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -1116,7 +1116,12 @@ cdef class Evaluation :
         if dictionary_info['blur_gauss_extent'] > 0 or dictionary_info['blur_core_extent'] > 0 :
             if stat_coeffs == 'all' :
                 ERROR( 'Not yet implemented. Unable to account for blur in case of multiple streamline constributions.' )
-            xic[ self.DICTIONARY['TRK']['kept']==1 ] *= self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
+            if len( dictionary_info["tractogram_centr_idx"] ) > 0 :
+                dictionary_info["tractogram_centr_idx"][dictionary_info["tractogram_centr_idx"]>0] *= xic[self.DICTIONARY['TRK']['kept']]
+                dictionary_info["tractogram_centr_idx"][dictionary_info["tractogram_centr_idx"]>0] *= self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
+                xic = dictionary_info["tractogram_centr_idx"]
+            else:
+                xic[ self.DICTIONARY['TRK']['kept']==1 ] *= self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
 
         np.savetxt( pjoin(RESULTS_path,'streamline_weights.txt'), xic, fmt=coeffs_format )
         self.set_config('stat_coeffs', stat_coeffs)

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -1116,14 +1116,19 @@ cdef class Evaluation :
         if dictionary_info['blur_gauss_extent'] > 0 or dictionary_info['blur_core_extent'] > 0 :
             if stat_coeffs == 'all' :
                 ERROR( 'Not yet implemented. Unable to account for blur in case of multiple streamline constributions.' )
-            if "tractogram_centr_idx" in dictionary_info.keys():
-                ordered_idx = dictionary_info["tractogram_centr_idx"].astype(np.int64)
-                unravel_weights = np.zeros( dictionary_info['n_count'], dtype=np.float64)
-                unravel_weights[ordered_idx] = self.DICTIONARY['TRK']['kept'].astype(np.float64)
+        if "tractogram_centr_idx" in dictionary_info.keys():
+            ordered_idx = dictionary_info["tractogram_centr_idx"].astype(np.int64)
+            unravel_weights = np.zeros( dictionary_info['n_count'], dtype=np.float64)
+            unravel_weights[ordered_idx] = self.DICTIONARY['TRK']['kept'].astype(np.float64)
+            if dictionary_info['blur_gauss_extent'] > 0 or dictionary_info['blur_core_extent'] > 0:
                 unravel_weights[unravel_weights>0] = xic[self.DICTIONARY['TRK']['kept']>0] * self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
                 xic = unravel_weights
-                
             else:
+                unravel_weights[unravel_weights>0] = xic[self.DICTIONARY['TRK']['kept']>0]
+                xic = unravel_weights
+                
+        else:
+            if dictionary_info['blur_gauss_extent'] > 0 or dictionary_info['blur_core_extent'] > 0:
                 xic[ self.DICTIONARY['TRK']['kept']==1 ] *= self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
 
         np.savetxt( pjoin(RESULTS_path,'streamline_weights.txt'), xic, fmt=coeffs_format )

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -1120,11 +1120,14 @@ cdef class Evaluation :
             ordered_idx = dictionary_info["tractogram_centr_idx"].astype(np.int64)
             unravel_weights = np.zeros( dictionary_info['n_count'], dtype=np.float64)
             unravel_weights[ordered_idx] = self.DICTIONARY['TRK']['kept'].astype(np.float64)
+            temp_weights = unravel_weights[ordered_idx]
             if dictionary_info['blur_gauss_extent'] > 0 or dictionary_info['blur_core_extent'] > 0:
-                unravel_weights[unravel_weights>0] = xic[self.DICTIONARY['TRK']['kept']>0] * self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
+                temp_weights[temp_weights>0] = xic[self.DICTIONARY['TRK']['kept']>0] * self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
+                unravel_weights[ordered_idx] = temp_weights
                 xic = unravel_weights
             else:
-                unravel_weights[unravel_weights>0] = xic[self.DICTIONARY['TRK']['kept']>0]
+                temp_weights[temp_weights>0] = xic[self.DICTIONARY['TRK']['kept']>0]
+                unravel_weights[ordered_idx] = temp_weights
                 xic = unravel_weights
                 
         else:

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -1117,9 +1117,12 @@ cdef class Evaluation :
             if stat_coeffs == 'all' :
                 ERROR( 'Not yet implemented. Unable to account for blur in case of multiple streamline constributions.' )
             if len( dictionary_info["tractogram_centr_idx"] ) > 0 :
-                dictionary_info["tractogram_centr_idx"][dictionary_info["tractogram_centr_idx"]>0] *= xic[self.DICTIONARY['TRK']['kept']]
-                dictionary_info["tractogram_centr_idx"][dictionary_info["tractogram_centr_idx"]>0] *= self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
-                xic = dictionary_info["tractogram_centr_idx"]
+                ordered_idx = dictionary_info["tractogram_centr_idx"].astype(np.int64)
+                unravel_weights = np.zeros( dictionary_info['n_count'], dtype=np.float64)
+                unravel_weights[ordered_idx] = self.DICTIONARY['TRK']['kept'].astype(np.float64)
+                unravel_weights[unravel_weights>0] = xic[self.DICTIONARY['TRK']['kept']>0] * self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
+                xic = unravel_weights
+                
             else:
                 xic[ self.DICTIONARY['TRK']['kept']==1 ] *= self.DICTIONARY['TRK']['lenTot'] / self.DICTIONARY['TRK']['len']
 

--- a/commit/core.pyx
+++ b/commit/core.pyx
@@ -396,6 +396,7 @@ cdef class Evaluation :
         if dictionary_info['ndirs'] != self.get_config('ndirs'):
             ERROR( '"ndirs" of the dictionary (%d) does not match with the kernels (%d)' % (dictionary_info['ndirs'], self.get_config('ndirs')) )
         self.DICTIONARY['ndirs'] = dictionary_info['ndirs']
+        self.DICTIONARY['n_threads'] = dictionary_info['n_threads']
 
         # load mask
         self.set_config('dictionary_mask', 'mask' if use_all_voxels_in_mask else 'tdi' )
@@ -527,12 +528,9 @@ cdef class Evaluation :
             Number of threads to use (default : number of CPUs in the system)
         """
         if n is None :
-            # Set to the number of CPUs in the system
-            try :
-                import multiprocessing
-                n = multiprocessing.cpu_count()
-            except :
-                n = 1
+            # Use the same number of threads used in trk2dictionary
+            n = self.DICTIONARY['n_threads']
+
 
         if n < 1 or n > 255 :
             ERROR( 'Number of threads must be between 1 and 255' )

--- a/commit/models.py
+++ b/commit/models.py
@@ -1,20 +1,31 @@
-import amico.models
+import sys
+from os import environ
+from amico.models import StickZeppelinBall as _StickZeppelinBall, CylinderZeppelinBall as _CylinderZeppelinBall, VolumeFractions as _VolumeFractions
+
+try:
+    sys.path.append(environ['AMICO_WIP_MODELS'])
+    from commitwipmodels import *
+except KeyError:
+    pass
+except ImportError:
+    pass
 
 
-class StickZeppelinBall( amico.models.StickZeppelinBall ) :
+
+class StickZeppelinBall(_StickZeppelinBall):
     """Simulate the response functions according to the Stick-Zeppelin-Ball model.
     See the AMICO.model module for details.
     """
     pass
 
 
-class CylinderZeppelinBall( amico.models.CylinderZeppelinBall ) :
+class CylinderZeppelinBall(_CylinderZeppelinBall):
     """Simulate the response functions according to the Cylinder-Zeppelin-Ball model.
     See the AMICO.model module for details.
     """
     pass
 
-class VolumeFractions( amico.models.VolumeFractions ) :
+class VolumeFractions(_VolumeFractions):
     """Simulate the response functions according to the VolumeFractions model.
     See the AMICO.model module for details.
     """

--- a/commit/trk2dictionary/ProgressBar.h
+++ b/commit/trk2dictionary/ProgressBar.h
@@ -20,11 +20,11 @@ class ProgressBar
         void    close();
 
         ProgressBar( unsigned int _N, unsigned int _width );
-        ProgressBar(unsigned int _width);
+        ProgressBar(unsigned int _width = 25);
         ~ProgressBar();
 };
 
-ProgressBar::ProgressBar(unsigned int _width = 25){
+ProgressBar::ProgressBar(unsigned int _width){
     width = _width;
 };
 

--- a/commit/trk2dictionary/ProgressBar.h
+++ b/commit/trk2dictionary/ProgressBar.h
@@ -20,9 +20,13 @@ class ProgressBar
         void    close();
 
         ProgressBar( unsigned int _N, unsigned int _width );
+        ProgressBar(unsigned int _width);
         ~ProgressBar();
 };
 
+ProgressBar::ProgressBar(unsigned int _width = 25){
+    width = _width;
+};
 
 ProgressBar::ProgressBar( unsigned int _N, unsigned int _width = 25 )
 {

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -300,7 +300,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         if blur_clust_groupby:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, atlas=blur_clust_groupby,
                             reference=blur_clust_groupby, clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
-                            n_threads=n_threads, split=True, force=True, verbose=False) 
+                            n_threads=n_threads, force=True, verbose=False) 
         else:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, reference=filename_reference, clust_thr=blur_clust_thr[0],
                             n_threads=n_threads, force=True)

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -57,7 +57,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
             vf_THR=0.1, peaks_use_affine=False, flip_peaks=[False,False,False], blur_clust_groupby=None,
             blur_clust_thr=0, blur_spacing=0.25, blur_core_extent=0.0, blur_gauss_extent=0.0,
             blur_gauss_min=0.1, blur_apply_to=None, TCK_ref_image=None, ndirs=500, n_threads=-1,
-            keep_temp=False, verbose=False
+            keep_temp=False, verbose=2
             ):
     """Perform the conversion of a tractoram to the sparse data-structure internally
     used by COMMIT to perform the matrix-vector multiplications with the operator A
@@ -143,6 +143,9 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
 
     keep_temp: boolean
         If True, the temporary files are not deleted (default : False).
+
+    verbose: int
+        Verbosity level (default : 2).
     """
 
     # check the value of ndirs
@@ -293,20 +296,19 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
 
         input_tractogram = os.path.basename(filename_tractogram)[:-4]
         filename_out = join( path_temp, f'{input_tractogram}_clustered_thr_{float(blur_clust_thr[0])}.tck' )
-        file_assignments = join( path_temp, f'{input_tractogram}_clustered_thr_{blur_clust_thr[0]}_assignments.txt' )
-        verbose_lvl = 4 if verbose else 1
 
         if blur_clust_groupby:
+            file_assignments = join( path_temp, f'{input_tractogram}_clustered_thr_{blur_clust_thr[0]}_assignments.txt' )
             hdr = nibabel.streamlines.load( filename_tractogram, lazy_load=True ).header
             temp_idx = np.arange(int(hdr['count']))
             path_streamline_idx = join( path_temp,"streamline_idx.npy")
             np.save( path_streamline_idx, temp_idx )
             idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, atlas=blur_clust_groupby,
                             clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
-                            temp_idx=path_streamline_idx, n_threads=n_threads, force=True, verbose=verbose_lvl) 
+                            temp_idx=path_streamline_idx, n_threads=n_threads, force=True, verbose=verbose) 
         else:
-            idx_centroids = run_clustering(file_name_in=filename_tractogram, clust_thr=blur_clust_thr[0],
-                            n_threads=n_threads, force=True, verbose=verbose_lvl)
+            idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, clust_thr=blur_clust_thr[0],
+                            force=True, verbose=verbose)
         filename_tractogram = filename_out
 
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -299,7 +299,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         if blur_clust_groupby:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, atlas=blur_clust_groupby,
                             reference=blur_clust_groupby, clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
-                            n_threads=n_threads, split=True, force=True, verbose=True) 
+                            n_threads=n_threads, split=True, force=True, verbose=False) 
         else:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, reference=filename_reference, clust_thr=blur_clust_thr[0],
                             n_threads=n_threads, force=True)
@@ -455,6 +455,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
     dictionary_info = {}
     dictionary_info['filename_tractogram'] = filename_tractogram
     if blur_clust_thr[0]> 0:
+        idx_centroids = np.array(idx_centroids, dtype=np.uint32)
         dictionary_info['n_count'] = input_n_count
         dictionary_info['tractogram_centr_idx'] = idx_centroids 
     dictionary_info['TCK_ref_image'] = TCK_ref_image

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -30,7 +30,7 @@ cdef extern from "trk2dictionary_c.cpp":
         char* filename_tractogram, int data_offset, int Nx, int Ny, int Nz, float Px, float Py, float Pz, int n_count, int n_scalars,
         int n_properties, float fiber_shiftX, float fiber_shiftY, float fiber_shiftZ, float min_seg_len, float min_fiber_len,  float max_fiber_len,
         float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int ECiz,
-        float* _ptrMASK, float** ptrTDI, char* path_out, int c, double* ptrPeaksAffine,
+        float* _ptrMASK, double** ptrTDI, char* path_out, int c, double* ptrPeaksAffine,
         int nReplicas, double* ptrBlurRho, double* ptrBlurAngle, double* ptrBlurWeights, bool* ptrBlurApplyTo,
         float* ptrTractsAffine, short* prtHashTable, int threads_count
     ) nogil
@@ -479,8 +479,8 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     cdef float* ptrPEAKS
     cdef float [:, :, :, ::1] niiPEAKS_img
     cdef int Np
-    cdef float [:,:, :,::1] niiTDI_img = np.ascontiguousarray( np.zeros((nthreads,Nx,Ny,Nz),dtype=np.float32) )
-    cdef float** ptrTDI = <float**>malloc( nthreads * sizeof(float*) )
+    cdef double [:,:, :,::1] niiTDI_img = np.ascontiguousarray( np.zeros((nthreads,Nx,Ny,Nz),dtype=np.float64) )
+    cdef double** ptrTDI = <double**>malloc( nthreads * sizeof(double*) )
     for i in range(nthreads):
         ptrTDI[i] = &niiTDI_img[i,0,0,0]
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -217,6 +217,9 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     blur_apply_to: array of bool
         For each input streamline, decide whether blur is applied or not to it (default : None, meaning apply to all).
 
+    blur_clust_thr: list of float
+        Clustering thresholds used to remove redundant streamlines from the input tractogram
+     
     ndirs : int
         Number of orientations on the sphere used to discretize the orientation of each
         each segment in a streamline (default : 500).
@@ -350,10 +353,6 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
             ERROR( '"path_out" cannot be inferred from "filename_tractogram"' )
         path_out = join(path_out,'COMMIT')
 
-    # create output path
-    print( f'\t- Output written to "{path_out}"' )
-    if not exists( path_out ):
-        makedirs( path_out )
 
     if nthreads is None :
         # Set to the number of CPUs in the system
@@ -367,12 +366,18 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
         ERROR( 'Number of nthreads must be between 1 and 255' )
     
     if nthreads > 1 :
+        print( f'\t- Using parallel computation with {nthreads} threads' )
         path_temp = join(path_out, 'temp')
         if exists(path_temp):
             shutil.rmtree(path_temp)
         makedirs(path_temp)
     else:
         path_temp = path_out
+
+     # create output path
+    print( f'\t- Output written to "{path_out}"' )
+    if not exists( path_out ):
+        makedirs( path_out )
 
 
     # Load data from files

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -78,7 +78,7 @@ def get_streamlines_close_to_centroids( clusters, streamlines, cluster_pts ):
     return centroids_out
 
 def tractogram_cluster( filename_in, filename_out, filename_reference, thresholds, n_pts=20, centroid_type='closer',
-                        random=True, verbose=False, smooth=False, get_size=False ):
+                        random=False, verbose=False, smooth=False, get_size=False ):
     """ Cluster streamlines in a tractogram.
     """
     if verbose :

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -299,7 +299,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
             else:
                 filename_reference = TCK_ref_image
 
-        filename_out = join(path_out,f'{filename_tractogram[:-4]}_clustered_thr_{blur_clust_thr[0]}.tck')
+        filename_out = join(path_out,f'{filename_tractogram[:-4]}_clustered_thr_{float(blur_clust_thr[0])}.tck')
         file_assignments = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr[0]}_assignments.txt')
         path_out_bundles = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr[0]}_bundles')
         print(f"file ass in commit: {file_assignments}")

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -7,7 +7,7 @@ cimport numpy as np
 from libc.stdlib cimport malloc, free
 import nibabel
 from dicelib.clustering import run_clustering
-
+from dicelib.tractogram import info as streamlines_count
 import os
 from os.path import join, exists, splitext, dirname, isdir, isfile
 from os import makedirs, remove, system, listdir
@@ -276,7 +276,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         blur_clust_thr = np.array( [blur_clust_thr] )
 
     if blur_clust_thr[0]> 0:
-        LOG( '\n-> Running tractogram clustering:' )
+        LOG( '\n   * Running tractogram clustering:' )
         print( f'\t- Input tractogram "{filename_tractogram}"' )
         print( f'\t- Clustering threshold = {blur_clust_thr}' )
         
@@ -301,11 +301,11 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         else:
             print( f'\t- Output tractogram "{filename_out}"' )
         if blur_clust_groupby:
-            run_clustering(file_name_in=filename_tractogram, output_folder=path_out_bundles, atlas=blur_clust_groupby,
+            idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_out_bundles, atlas=blur_clust_groupby,
                             reference=blur_clust_groupby, clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
                             n_threads=n_threads, split=True, force=True) 
         else:
-            run_clustering(file_name_in=filename_tractogram, reference=filename_reference, clust_thr=blur_clust_thr[0],
+            idx_centroids = run_clustering(file_name_in=filename_tractogram, reference=filename_reference, clust_thr=blur_clust_thr[0],
                             n_threads=n_threads, force=True)
 
         filename_tractogram = filename_out
@@ -454,6 +454,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
     # write dictionary information info file
     dictionary_info = {}
     dictionary_info['filename_tractogram'] = filename_tractogram
+    dictionary_info['tractogram_centr_idx'] = idx_centroids 
     dictionary_info['TCK_ref_image'] = TCK_ref_image
     dictionary_info['path_out'] = path_out
     dictionary_info['filename_peaks'] = filename_peaks

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -273,7 +273,6 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
     if np.isscalar(blur_clust_thr):
         blur_clust_thr = np.array( [blur_clust_thr] )
 
-    input_n_count = 0
     if blur_clust_thr[0]> 0:
         LOG( '\n   * Running tractogram clustering:' )
         print( f'\t- Input tractogram "{filename_tractogram}"' )
@@ -455,8 +454,9 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
     # write dictionary information info file
     dictionary_info = {}
     dictionary_info['filename_tractogram'] = filename_tractogram
-    dictionary_info['n_count'] = input_n_count
-    dictionary_info['tractogram_centr_idx'] = idx_centroids 
+    if blur_clust_thr[0]> 0:
+        dictionary_info['n_count'] = input_n_count
+        dictionary_info['tractogram_centr_idx'] = idx_centroids 
     dictionary_info['TCK_ref_image'] = TCK_ref_image
     dictionary_info['path_out'] = path_out
     dictionary_info['filename_peaks'] = filename_peaks

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -56,8 +56,9 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
             do_intersect=True, fiber_shift=0, min_seg_len=1e-3, min_fiber_len=0.0, max_fiber_len=250.0,
             vf_THR=0.1, peaks_use_affine=False, flip_peaks=[False,False,False], blur_clust_groupby=None,
             blur_clust_thr=0, blur_spacing=0.25, blur_core_extent=0.0, blur_gauss_extent=0.0,
-            blur_gauss_min=0.1, blur_apply_to=None, TCK_ref_image=None, ndirs=500, n_threads=None
-    ):
+            blur_gauss_min=0.1, blur_apply_to=None, TCK_ref_image=None, ndirs=500, n_threads=None,
+            keep_temp=False
+            ):
     """Perform the conversion of a tractoram to the sparse data-structure internally
     used by COMMIT to perform the matrix-vector multiplications with the operator A
     during the inversion of the linear system.
@@ -584,7 +585,8 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
     niiMASK_hdr['descrip'] = niiTDI_hdr['descrip']
     nibabel.save( niiMASK, join(path_out,'dictionary_mask.nii.gz') )
 
-    shutil.rmtree(path_temp)
+    if not keep_temp:
+        shutil.rmtree(path_temp)
 
 
     LOG( f'\n   [ {time.time() - tic:.1f} seconds ]' )

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -604,12 +604,6 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
         dict_list += [ path_out+f'/dictionary_IC_len_{j}.dict' ]
     cat_function( dict_list, fileout )
 
-    fileout = path_out + '/dictionary_EC_v.dict'
-    dict_list = []
-    for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_EC_v_{j}.dict' ]
-    cat_function( dict_list, fileout )
-
     # save TDI and MASK maps
     if TCK_ref_image is not None:
         TDI_affine = _get_affine( niiREF )

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -365,6 +365,15 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
 
     if threads < 1 or threads > 255 :
         ERROR( 'Number of threads must be between 1 and 255' )
+    
+    if threads > 1 :
+        path_temp = join(path_out 'temp')
+        if os.path.exists(path_temp):
+            shutil.rmtree(path_temp)
+        os.makedirs(path_temp)
+    else:
+        path_temp = path_out
+
 
     # Load data from files
     LOG( '\n   * Loading data:' )
@@ -559,49 +568,49 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     fileout = path_out + '/dictionary_TRK_kept.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_TRK_kept_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_TRK_kept_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     fileout = path_out + '/dictionary_TRK_norm.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_TRK_norm_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_TRK_norm_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     fileout = path_out + '/dictionary_TRK_len.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_TRK_len_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_TRK_len_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     fileout = path_out + '/dictionary_TRK_lenTot.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_TRK_lenTot_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_TRK_lenTot_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     fileout = path_out + '/dictionary_IC_f.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_IC_f_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_IC_f_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     fileout = path_out + '/dictionary_IC_v.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_IC_v_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_IC_v_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     fileout = path_out + '/dictionary_IC_o.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_IC_o_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_IC_o_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     fileout = path_out + '/dictionary_IC_len.dict'
     dict_list = []
     for j in range(threads):
-        dict_list += [ path_out+f'/dictionary_IC_len_{j}.dict' ]
+        dict_list += [ path_temp + f'/dictionary_IC_len_{j}.dict' ]
     cat_function( dict_list, fileout )
 
     # save TDI and MASK maps
@@ -632,5 +641,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     nibabel.save( niiMASK, join(path_out,'dictionary_mask.nii.gz') )
 
     free( ptrTDI )
+    if os.path.exists(path_temp):
+        shutil.rmtree(path_temp)
 
     LOG( f'\n   [ {time.time() - tic:.1f} seconds ]' )

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -368,9 +368,9 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     
     if nthreads > 1 :
         path_temp = join(path_out, 'temp')
-        if os.path.exists(path_temp):
+        if exists(path_temp):
             shutil.rmtree(path_temp)
-        os.makedirs(path_temp)
+        makedirs(path_temp)
     else:
         path_temp = path_out
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -632,7 +632,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     for i in range(nthreads):
         niiTDI_img_save += niiTDI_img[i,:,:,:]
 
-    niiTDI = nibabel.Nifti1Image( niiTDI_img_save, TDI_affine )
+    niiTDI = nibabel.Nifti1Image( niiTDI_img_save.astype(np.float32), TDI_affine )
     niiTDI_hdr = _get_header( niiTDI )
     niiTDI_hdr['descrip'] = f'Created with COMMIT {get_distribution("dmri-commit").version}'
     nibabel.save( niiTDI, join(path_out,'dictionary_tdi.nii.gz') )

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -294,6 +294,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         input_tractogram = os.path.basename(filename_tractogram)[:-4]
         filename_out = join( path_temp, f'{input_tractogram}_clustered_thr_{float(blur_clust_thr[0])}.tck' )
         file_assignments = join( path_temp, f'{input_tractogram}_clustered_thr_{blur_clust_thr[0]}_assignments.txt' )
+        verbose_lvl = 4 if verbose else 1
 
         if blur_clust_groupby:
             hdr = nibabel.streamlines.load( filename_tractogram, lazy_load=True ).header
@@ -302,10 +303,10 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
             np.save( path_streamline_idx, temp_idx )
             idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, atlas=blur_clust_groupby,
                             clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
-                            temp_idx=path_streamline_idx, n_threads=n_threads, force=True, verbose=verbose) 
+                            temp_idx=path_streamline_idx, n_threads=n_threads, force=True, verbose=verbose_lvl) 
         else:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, clust_thr=blur_clust_thr[0],
-                            n_threads=n_threads, force=True, verbose=verbose)
+                            n_threads=n_threads, force=True, verbose=verbose_lvl)
         filename_tractogram = filename_out
 
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -57,7 +57,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
             vf_THR=0.1, peaks_use_affine=False, flip_peaks=[False,False,False], blur_clust_groupby=None,
             blur_clust_thr=0, blur_spacing=0.25, blur_core_extent=0.0, blur_gauss_extent=0.0,
             blur_gauss_min=0.1, blur_apply_to=None, TCK_ref_image=None, ndirs=500, n_threads=None,
-            keep_temp=False
+            keep_temp=False, verbose=False
             ):
     """Perform the conversion of a tractoram to the sparse data-structure internally
     used by COMMIT to perform the matrix-vector multiplications with the operator A
@@ -298,12 +298,16 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         file_assignments = join( path_temp, f'{input_tractogram}_clustered_thr_{blur_clust_thr[0]}_assignments.txt' )
 
         if blur_clust_groupby:
+            hdr = nibabel.streamlines.load( filename_tractogram, lazy_load=True ).header
+            temp_idx = np.arange(int(hdr['count']))
+            path_streamline_idx = join( path_temp,"streamline_idx.npy")
+            np.save( path_streamline_idx, temp_idx )
             idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, atlas=blur_clust_groupby,
                             reference=blur_clust_groupby, clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
-                            n_threads=n_threads, force=True, verbose=False) 
+                            temp_idx=path_streamline_idx, n_threads=n_threads, force=True, verbose=verbose) 
         else:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, reference=filename_reference, clust_thr=blur_clust_thr[0],
-                            n_threads=n_threads, force=True)
+                            n_threads=n_threads, force=True, verbose=verbose)
         filename_tractogram = filename_out
 
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -254,7 +254,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
     print( f'\t- Temporary files written to "{path_temp}"' )
     
     if exists(path_temp):
-        shutil.rmtree(path_temp)
+        shutil.rmtree(path_temp, ignore_errors=True)
     makedirs(path_temp)
 
     if n_threads is None :
@@ -303,7 +303,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
             path_streamline_idx = join( path_temp,"streamline_idx.npy")
             np.save( path_streamline_idx, temp_idx )
             idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, atlas=blur_clust_groupby,
-                            reference=blur_clust_groupby, clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
+                            clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
                             temp_idx=path_streamline_idx, n_threads=n_threads, force=True, verbose=verbose) 
         else:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, clust_thr=blur_clust_thr[0],

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -1,22 +1,20 @@
 #!python
 # cython: language_level=3, c_string_type=str, c_string_encoding=ascii, boundscheck=False, wraparound=False, profile=False
 from __future__ import print_function
-import cython
 import numpy as np
 cimport numpy as np
 from libc.stdlib cimport malloc, free
 import nibabel
 from dicelib.clustering import run_clustering
-from dicelib.tractogram import info as streamlines_count
+
 import os
 from os.path import join, exists, splitext, dirname, isdir, isfile
-from os import makedirs, remove, system, listdir
+from os import makedirs, remove
 import time
 import amico
 import pickle
 from amico.util import LOG, NOTE, WARNING, ERROR
 from pkg_resources import get_distribution
-import multiprocessing
 import shutil
 
 from libcpp cimport bool
@@ -275,6 +273,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
     if np.isscalar(blur_clust_thr):
         blur_clust_thr = np.array( [blur_clust_thr] )
 
+    input_n_count = 0
     if blur_clust_thr[0]> 0:
         LOG( '\n   * Running tractogram clustering:' )
         print( f'\t- Input tractogram "{filename_tractogram}"' )
@@ -301,11 +300,12 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
         if blur_clust_groupby:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, output_folder=path_temp, atlas=blur_clust_groupby,
                             reference=blur_clust_groupby, clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
-                            n_threads=n_threads, split=True, force=True) 
+                            n_threads=n_threads, split=True, force=True, verbose=True) 
         else:
             idx_centroids = run_clustering(file_name_in=filename_tractogram, reference=filename_reference, clust_thr=blur_clust_thr[0],
                             n_threads=n_threads, force=True)
         filename_tractogram = filename_out
+
 
 
     # Load data from files

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -57,7 +57,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
             vf_THR=0.1, peaks_use_affine=False, flip_peaks=[False,False,False], blur_clust_groupby=None,
             blur_clust_thr=0, blur_spacing=0.25, blur_core_extent=0.0, blur_gauss_extent=0.0,
             blur_gauss_min=0.1, blur_apply_to=None, TCK_ref_image=None, ndirs=500, n_threads=None,
-            keep_temp=False
+            keep_temp=False, verbose=False
             ):
     """Perform the conversion of a tractoram to the sparse data-structure internally
     used by COMMIT to perform the matrix-vector multiplications with the operator A
@@ -306,7 +306,7 @@ cpdef run( filename_tractogram=None, path_out=None, filename_peaks=None, filenam
                             reference=blur_clust_groupby, clust_thr=blur_clust_thr[0], save_assignments=file_assignments,
                             temp_idx=path_streamline_idx, n_threads=n_threads, force=True, verbose=verbose) 
         else:
-            idx_centroids = run_clustering(file_name_in=filename_tractogram, reference=filename_reference, clust_thr=blur_clust_thr[0],
+            idx_centroids = run_clustering(file_name_in=filename_tractogram, clust_thr=blur_clust_thr[0],
                             n_threads=n_threads, force=True)
         filename_tractogram = filename_out
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -299,18 +299,20 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
             else:
                 filename_reference = TCK_ref_image
 
-        filename_out = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr}.tck')
+        filename_out = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr[0]}.tck')
+        file_assignments = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr[0]}_assignments.txt')
+        print(f"file ass in commit: {file_assignments}")
         if isfile(filename_out):
             print( f'\t- Overwriting tractogram "{filename_out}"' )
         else:
             print( f'\t- Output tractogram "{filename_out}"' )
         if filename_atlas:
-            os.system(f"dicelib_tractogram_cluster {filename_tractogram} --reference {filename_reference}"+
-            f"--threshold {blur_clust_thr} --out {path_out} --atlas {filename_atlas}"+
-            f"--nthreads {nthreads}")
+            os.system(f"dice_tractogram_cluster.py {filename_tractogram} --reference {filename_reference} "+
+            f"--clust_threshold {blur_clust_thr[0]} --out {path_out} --atlas {filename_atlas} "+
+            f"--n_threads {nthreads} --save_assignments {file_assignments}")
         else:
-            os.system(f"dicelib_tractogram_cluster {filename_tractogram} --reference {filename_reference}"+
-            f"--threshold {blur_clust_thr} --out {path_out} --nthreads {nthreads}")
+            os.system(f"dice_tractogram_cluster.py {filename_tractogram} --reference {filename_reference} "+
+            f"--clust_threshold {blur_clust_thr[0]} --out {path_out} --n_threads {nthreads}")
 
         filename_tractogram = filename_out
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -641,7 +641,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     nibabel.save( niiMASK, join(path_out,'dictionary_mask.nii.gz') )
 
     free( ptrTDI )
-    if os.path.exists(path_temp):
+    if exists(path_temp):
         shutil.rmtree(path_temp)
 
     LOG( f'\n   [ {time.time() - tic:.1f} seconds ]' )

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -405,9 +405,9 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
 
     if extension == ".trk":
         print ( f'\t\t- geometry taken from "{filename_tractogram}"' )
-        Nx = hdr['dimensions'][0]
-        Ny = hdr['dimensions'][1]
-        Nz = hdr['dimensions'][2]
+        Nx = int(hdr['dimensions'][0])
+        Ny = int(hdr['dimensions'][1])
+        Nz = int(hdr['dimensions'][2])
         Px = hdr['voxel_sizes'][0]
         Py = hdr['voxel_sizes'][1]
         Pz = hdr['voxel_sizes'][2]
@@ -639,7 +639,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     v = np.fromfile( join(path_out, 'dictionary_IC_v.dict'),   dtype=np.uint32 )
     l = np.fromfile( join(path_out, 'dictionary_IC_len.dict'), dtype=np.float32 )
 
-    cdef np.float32_t [::1] niiTDI_mem = np.zeros( niiMASK.shape[0]*niiMASK.shape[1]*niiMASK.shape[2], dtype=np.float32 )
+    cdef np.float32_t [::1] niiTDI_mem = np.zeros( Nx*Ny*Nz, dtype=np.float32 )
     niiTDI_mem = compute_tdi( v, l, Nx, Ny, Nz )
     niiTDI_img_save = np.reshape( niiTDI_mem, niiMASK.shape, order='F' )
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -367,7 +367,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
         ERROR( 'Number of nthreads must be between 1 and 255' )
     
     if nthreads > 1 :
-        path_temp = join(path_out 'temp')
+        path_temp = join(path_out, 'temp')
         if os.path.exists(path_temp):
             shutil.rmtree(path_temp)
         os.makedirs(path_temp)

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -639,7 +639,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     v = np.fromfile( join(path_out, 'dictionary_IC_v.dict'),   dtype=np.uint32 )
     l = np.fromfile( join(path_out, 'dictionary_IC_len.dict'), dtype=np.float32 )
 
-    cdef np.float32_t [::1] niiTDI_mem = np.zeros( Nx*Ny*Nz, dtype=np.float32 )
+    cdef np.float32_t [::1] niiTDI_mem = np.zeros( niiMASK.shape[0]*niiMASK.shape[1]*niiMASK.shape[2], dtype=np.float32 )
     niiTDI_mem = compute_tdi( v, l, Nx, Ny, Nz )
     niiTDI_img_save = np.reshape( niiTDI_mem, niiMASK.shape, order='F' )
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -299,20 +299,21 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
             else:
                 filename_reference = TCK_ref_image
 
-        filename_out = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr[0]}.tck')
+        filename_out = join(path_out,f'{filename_tractogram[:-4]}_clustered_thr_{blur_clust_thr[0]}.tck')
         file_assignments = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr[0]}_assignments.txt')
+        path_out_bundles = join(path_out,f'{filename_tractogram}_clustered_thr_{blur_clust_thr[0]}_bundles')
         print(f"file ass in commit: {file_assignments}")
         if isfile(filename_out):
             print( f'\t- Overwriting tractogram "{filename_out}"' )
         else:
             print( f'\t- Output tractogram "{filename_out}"' )
         if filename_atlas:
-            os.system(f"dice_tractogram_cluster.py {filename_tractogram} --reference {filename_reference} "+
-            f"--clust_threshold {blur_clust_thr[0]} --out {path_out} --atlas {filename_atlas} "+
-            f"--n_threads {nthreads} --save_assignments {file_assignments}")
+            os.system(f"dice_tractogram_cluster.py {filename_tractogram} --reference {filename_atlas} "+
+            f"--clust_threshold {blur_clust_thr[0]} --out {path_out_bundles} --atlas {filename_atlas} "+
+            f"--split --n_threads {nthreads} --save_assignments {file_assignments} -f")
         else:
-            os.system(f"dice_tractogram_cluster.py {filename_tractogram} --reference {filename_reference} "+
-            f"--clust_threshold {blur_clust_thr[0]} --out {path_out} --n_threads {nthreads}")
+            os.system(f"dice_tractogram_cluster.py {filename_tractogram} --reference {filename_atlas} "+
+            f"--split --clust_threshold {blur_clust_thr[0]} --out {path_out_bundles} --n_threads {nthreads} -f")
 
         filename_tractogram = filename_out
 

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -545,7 +545,7 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
         Nx, Ny, Nz, Px, Py, Pz, n_count, n_scalars, n_properties,
         fiber_shiftX, fiber_shiftY, fiber_shiftZ, min_seg_len, min_fiber_len, max_fiber_len,
         ptrPEAKS, Np, vf_THR, -1 if flip_peaks[0] else 1, -1 if flip_peaks[1] else 1, -1 if flip_peaks[2] else 1,
-        ptrMASK, ptrTDI, path_out, 1 if do_intersect else 0, ptrPeaksAffine,
+        ptrMASK, ptrTDI, path_temp, 1 if do_intersect else 0, ptrPeaksAffine,
         nReplicas, &blurRho[0], &blurAngle[0], &blurWeights[0], &blurApplyTo[0], ptrToVOXMM, ptrHashTable, nthreads  );
     if ret == 0 :
         WARNING( 'DICTIONARY not generated' )

--- a/commit/trk2dictionary/trk2dictionary.pyx
+++ b/commit/trk2dictionary/trk2dictionary.pyx
@@ -554,9 +554,9 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     # Concatenate files together
     cdef int discarded = 0
     for j in range(nthreads-1):
-        path_IC_f = path_out + f'/dictionary_IC_f_{j+1}.dict'
-        kept = np.fromfile( path_out + f'/dictionary_TRK_kept_{j}.dict', dtype=np.uint8 )
-        IC_f = np.fromfile( path_out + f'/dictionary_IC_f_{j+1}.dict', dtype=np.uint32 )
+        path_IC_f = path_temp + f'/dictionary_IC_f_{j+1}.dict'
+        kept = np.fromfile( path_temp + f'/dictionary_TRK_kept_{j}.dict', dtype=np.uint8 )
+        IC_f = np.fromfile( path_temp + f'/dictionary_IC_f_{j+1}.dict', dtype=np.uint32 )
         discarded += np.count_nonzero(kept==0)
         IC_f -= discarded
         IC_f_save = np.memmap( path_IC_f, dtype="uint32", mode='w+', shape=IC_f.shape )
@@ -641,7 +641,8 @@ cpdef run( filename_tractogram=None, path_out=None, blur_clust_thr=0, filename_p
     nibabel.save( niiMASK, join(path_out,'dictionary_mask.nii.gz') )
 
     free( ptrTDI )
-    if exists(path_temp):
+    if nthreads > 1:
         shutil.rmtree(path_temp)
+
 
     LOG( f'\n   [ {time.time() - tic:.1f} seconds ]' )

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -266,6 +266,9 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
     // Variables definition
     string    filename;
     string    OUTPUT_path(path_out);
+    std::size_t pos = OUTPUT_path.find("/temp");
+    OUTPUT_path = str.substr (0,pos);
+
     unsigned short o;
     unsigned int v;
 

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -239,7 +239,8 @@ int trk2dictionary(
 
 
     printf( "     [ %d streamlines kept, %d segments in total ]\n", std::accumulate(totFibers.begin(), totFibers.end(), 0), std::accumulate( totICSegments.begin(), totICSegments.end(), 0) );
-
+    totFibers.clear();
+    totICSegments.clear();
     threads.clear();
     printf( "\n   \033[0;32m* Exporting EC compartments:\033[0m\n" );
 

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -244,6 +244,8 @@ int trk2dictionary(
     }
 
     PROGRESS->close();
+    totFibers.clear();
+
     printf( "     [ %d streamlines kept, %d segments in total ]\n", std::accumulate(totFibers.begin(), totFibers.end(), 0), std::accumulate( totICSegments.begin(), totICSegments.end(), 0) );
 
     threads.clear();

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -300,7 +300,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
                         skip = 0;
                         continue;
                     }
-
+                    skip = 0;
                     peakMax = -1;
                     for(id=0; id<Np ;id++)
                     {

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -91,11 +91,11 @@ unsigned int read_fiberTCK( FILE* fp, float fiber[3][MAX_FIB_LEN] , float* toVOX
 
 // ---------- Parallel fuction --------------
 int ICSegments( char* str_filename, int isTRK, int n_count, int nReplicas, int n_scalars, int n_properties, float* ptrToVOXMM,
-float* ptrTDI , double* ptrBlurRho, double* ptrBlurAngle, double* ptrBlurWeights, bool* ptrBlurApplyTo, short* ptrHashTable, char* path_out, 
+double* ptrTDI , double* ptrBlurRho, double* ptrBlurAngle, double* ptrBlurWeights, bool* ptrBlurApplyTo, short* ptrHashTable, char* path_out, 
 unsigned long long int offset, int idx, unsigned int startpos, unsigned int endpos );
 
 int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int ECiz,
-    float** ptrTDI, short* ptrHashTable, char* path_out, double* ptrPeaksAffine, int idx);
+    double** ptrTDI, short* ptrHashTable, char* path_out, double* ptrPeaksAffine, int idx);
 
 
 
@@ -107,7 +107,7 @@ int trk2dictionary(
     char* str_filename, int data_offset, int Nx, int Ny, int Nz, float Px, float Py, float Pz, int n_count, int n_scalars, int n_properties,
     float fiber_shiftX, float fiber_shiftY, float fiber_shiftZ, float min_seg_len, float min_fiber_len, float max_fiber_len,
     float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int ECiz,
-    float* _ptrMASK, float** ptrTDI, char* path_out, int c, double* ptrPeaksAffine,
+    float* _ptrMASK, double** ptrTDI, char* path_out, int c, double* ptrPeaksAffine,
     int nReplicas, double* ptrBlurRho, double* ptrBlurAngle, double* ptrBlurWeights, bool* ptrBlurApplyTo,
     float* ptrToVOXMM, short* ptrHashTable, int threads_count
 )
@@ -259,7 +259,7 @@ int trk2dictionary(
 
 
 int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int ECiz,
-    float** ptrTDI, short* ptrHashTable, char* path_out, double* ptrPeaksAffine, int threads){
+    double** ptrTDI, short* ptrHashTable, char* path_out, double* ptrPeaksAffine, int threads){
 
     // Variables definition
     string    filename;
@@ -379,7 +379,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
 /*                                                Parallel Function                                                 */
 /********************************************************************************************************************/
 
-int ICSegments( char* str_filename, int isTRK, int n_count, int nReplicas, int n_scalars, int n_properties, float* ptrToVOXMM, float* ptrTDI, double* ptrBlurRho, 
+int ICSegments( char* str_filename, int isTRK, int n_count, int nReplicas, int n_scalars, int n_properties, float* ptrToVOXMM, double* ptrTDI, double* ptrBlurRho, 
 double* ptrBlurAngle, double* ptrBlurWeights, bool* ptrBlurApplyTo, short* ptrHashTable, char* path_out, 
 unsigned long long int offset, int idx, unsigned int startpos, unsigned int endpos ) 
 {

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -267,7 +267,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
     string    filename;
     string    OUTPUT_path(path_out);
     std::size_t pos = OUTPUT_path.find("/temp");
-    OUTPUT_path = str.substr (0,pos);
+    OUTPUT_path = OUTPUT_path.substr (0,pos);
 
     unsigned short o;
     unsigned int v;

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -296,7 +296,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
                             skip += 1;
                         }
                     }
-                    if(skip==threads-1){
+                    if(skip==threads){
                         skip = 0;
                         continue;
                     }

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -131,10 +131,6 @@ int trk2dictionary(
     totECSegments = 0;
 
 
-
-    printf("\n   \033[0;32m* %d concurrent threads are supported\n ", threads_count ); 
-
-
     // Compute the batch size for each thread
     // ---------------------------------------
     int p_size = n_count > threads_count ? threads_count : n_count;
@@ -187,13 +183,11 @@ int trk2dictionary(
     OffsetArr[0] = ftell( fpTractogram );
 
     if(isTRK) {
-        // TODO: check if the file is a TRK file
         while( f != n_count) {
             fread( (char*)&N, 1, 4, fpTractogram ); // read the number of points in each streamline
             if( N >= MAX_FIB_LEN || N <= 0 ) return 0;   // check
             for( int k=0; k<N; k++){
                 fread((char*)Buff, 1, 12, fpTractogram);
-                // fseek(fpTractogram,4*n_scalars,SEEK_CUR);
             }
             fseek(fpTractogram,4*n_properties,SEEK_CUR);
             f++;
@@ -256,14 +250,6 @@ int trk2dictionary(
     printf( "\n   \033[0;32m* Exporting EC compartments:\033[0m\n" );
 
     int EC = ECSegments( ptrPEAKS, Np, vf_THR, ECix, ECiy, ECiz, ptrTDI, ptrHashTable, path_out, ptrPeaksAffine, threads_count );
-    // for( int i = 0; i<threads_count; i++ ) {
-    //     threads.push_back( thread( ECSegments, ptrPEAKS, Np, vf_THR, ECix, ECiy, ECiz, ptrMASK, ptrTDI[i], ptrHashTable,
-    //                             path_out, ptrPeaksAffine, i) );
-    // }
-
-    // for( int i = 0; i<threads_count; i++ ) {
-    //     threads[i].join();
-    // }
 
     printf("     [ %d voxels, %d segments ]\n", totECVoxels, totECSegments );
 

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -124,8 +124,8 @@ int trk2dictionary(
     minSegLen     = min_seg_len;
     minFiberLen   = min_fiber_len;
     maxFiberLen   = max_fiber_len;
-    totICSegments.resize( MAX_THREADS, 0 );
-    totFibers.resize( MAX_THREADS, 0 );
+    totICSegments.resize( threads_count, 0 );
+    totFibers.resize( threads_count, 0 );
     totECVoxels   = 0;
     totECSegments = 0;
 

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -17,7 +17,7 @@
 #define MAX_THREADS 255
 
 using namespace std;
-ProgressBar PROGRESS;
+ProgressBar* PROGRESS = new ProgressBar();
 
 // CLASS to store the segments of one fiber
 class segKey
@@ -227,10 +227,10 @@ int trk2dictionary(
     // ==========================================
 
     printf( "\n   \033[0;32m* Exporting IC compartments:\033[0m\n" );
-    
-
-    PROGRESS.reset((unsigned int) n_count);
-    PROGRESS.setPrefix("     ");
+    // unsigned int width = 25;
+    // PROGRESS = new ProgressBar( (unsigned int) n_count, (unsigned int) width);
+    PROGRESS->reset((unsigned int) n_count);
+    PROGRESS->setPrefix("     ");
     // ---- Original ------
     for( int i = 0; i<threads_count; i++ ){
         threads.push_back( thread( ICSegments, str_filename, isTRK, n_count, nReplicas, n_scalars, n_properties, ptrToVOXMM,
@@ -243,7 +243,7 @@ int trk2dictionary(
         threads[i].join();
     }
 
-    PROGRESS.close();
+    PROGRESS->close();
     printf( "     [ %d streamlines kept, %d segments in total ]\n", std::accumulate(totFibers.begin(), totFibers.end(), 0), std::accumulate( totICSegments.begin(), totICSegments.end(), 0) );
 
     threads.clear();
@@ -489,7 +489,7 @@ unsigned long long int offset, int idx, unsigned int startpos, unsigned int endp
         if (idx == 0){
             incr_new = std::accumulate(totFibers.begin(), totFibers.end(), 0);
             for(int i=incr_old; i<incr_new; i++)
-                PROGRESS.inc();
+                PROGRESS->inc();
             incr_old = incr_new;
         }
     }

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -271,7 +271,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
 
     unsigned short o;
     unsigned int v;
-    unsigned int   temp_totECSegments, temp_totECVoxels;
+    unsigned int temp_totECSegments = 0, temp_totECVoxels = 0;
 
 
     filename = OUTPUT_path+"/dictionary_EC_v.dict";        FILE* pDict_EC_v       = fopen(filename.c_str(),"wb");
@@ -288,8 +288,6 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
         float          *ptr;
         int            ox, oy;
         int            skip = 0;
-        temp_totECSegments = 0;
-        temp_totECVoxels = 0;
 
         for(iz=0; iz<dim.z; iz++)
         {

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -271,6 +271,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
 
     unsigned short o;
     unsigned int v;
+    unsigned int   temp_totECSegments, temp_totECVoxels;
 
 
     filename = OUTPUT_path+"/dictionary_EC_v.dict";        FILE* pDict_EC_v       = fopen(filename.c_str(),"wb");
@@ -281,7 +282,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
         Vector<double> dir;
         double         longitude, colatitude;
         segKey         ec_seg;
-        int            ix, iy, iz, id, atLeastOne, temp_totECSegments, temp_totECVoxels;
+        int            ix, iy, iz, id, atLeastOne;
         float          peakMax;
         float          norms[ Np ];
         float          *ptr;
@@ -356,7 +357,7 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
                         o = ptrHashTable[ox*181 + oy];
                         fwrite( &v, 4, 1, pDict_EC_v );
                         fwrite( &o, 2, 1, pDict_EC_o );
-                        temp_totECSegments ++;
+                        temp_totECSegments++;
                         atLeastOne = 1;
                         }
                     if ( atLeastOne>0 )

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -281,12 +281,14 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
         Vector<double> dir;
         double         longitude, colatitude;
         segKey         ec_seg;
-        int            ix, iy, iz, id, atLeastOne;
+        int            ix, iy, iz, id, atLeastOne, temp_totECSegments, temp_totECVoxels;
         float          peakMax;
         float          norms[ Np ];
         float          *ptr;
         int            ox, oy;
         int            skip = 0;
+        temp_totECSegments = 0;
+        temp_totECVoxels = 0;
 
         for(iz=0; iz<dim.z; iz++)
         {
@@ -354,15 +356,17 @@ int ECSegments(float* ptrPEAKS, int Np, float vf_THR, int ECix, int ECiy, int EC
                         o = ptrHashTable[ox*181 + oy];
                         fwrite( &v, 4, 1, pDict_EC_v );
                         fwrite( &o, 2, 1, pDict_EC_o );
-                        totECSegments ++;
+                        temp_totECSegments ++;
                         atLeastOne = 1;
                         }
                     if ( atLeastOne>0 )
-                        totECVoxels++;
+                        temp_totECVoxels++;
                     }
                 }
         }
     }
+    totECSegments = temp_totECSegments;
+    totECVoxels = temp_totECVoxels;
 
     fclose( pDict_EC_v );
     fclose( pDict_EC_o );
@@ -386,7 +390,7 @@ unsigned long long int offset, int idx, unsigned int startpos, unsigned int endp
     // Variables definition
     float           fiber[3][MAX_FIB_LEN] = {0} ;
     float           fiberNorm;   // normalization
-    unsigned int    N, v, tempTotFibers;
+    unsigned int    N, v, tempTotFibers, temp_totICSegments;
     unsigned short  o;
     unsigned char   kept;
     string          filename;
@@ -425,6 +429,7 @@ unsigned long long int offset, int idx, unsigned int startpos, unsigned int endp
     fseek(fpTractogram1, offset, SEEK_SET);
 
     tempTotFibers = 0;
+    temp_totICSegments = 0;
     // Iterate over streamlines
     for(int f=startpos; f<endpos; f++) 
     {        
@@ -470,7 +475,7 @@ unsigned long long int offset, int idx, unsigned int startpos, unsigned int endp
                 fwrite( &FiberLen,    1, 4, pDict_TRK_len );    // length of the streamline
                 fwrite( &FiberLenTot, 1, 4, pDict_TRK_lenTot ); // length of the streamline (considering the blur)
 
-                totICSegments[idx] += FiberSegments.size();
+                temp_totICSegments += FiberSegments.size();
                 sumFibers ++;
                 tempTotFibers ++;
                 kept = 1;
@@ -480,6 +485,7 @@ unsigned long long int offset, int idx, unsigned int startpos, unsigned int endp
 
         fwrite( &kept, 1, 1, pDict_TRK_kept );
         totFibers[idx] = tempTotFibers;
+        totICSegments[idx] = temp_totICSegments;
     }
 
     fclose( fpTractogram1 );

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -244,10 +244,9 @@ int trk2dictionary(
     }
 
     PROGRESS->close();
-    totFibers.clear();
 
     printf( "     [ %d streamlines kept, %d segments in total ]\n", std::accumulate(totFibers.begin(), totFibers.end(), 0), std::accumulate( totICSegments.begin(), totICSegments.end(), 0) );
-
+    totFibers.clear();
     threads.clear();
     printf( "\n   \033[0;32m* Exporting EC compartments:\033[0m\n" );
 

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -74,8 +74,8 @@ float           minSegLen, minFiberLen, maxFiberLen;
 
 // Threads variables
 vector<thread>  threads;
-vector<unsigned int>    totICSegments( MAX_THREADS, 0 ); 
-vector<unsigned int>    totFibers( MAX_THREADS, 0 );
+vector<unsigned int>    totICSegments; 
+vector<unsigned int>    totFibers;
 unsigned int            totECVoxels = 0;
 unsigned int            totECSegments = 0;
 

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -193,11 +193,15 @@ int trk2dictionary(
             if( N >= MAX_FIB_LEN || N <= 0 ) return 0;   // check
             for( int k=0; k<N; k++){
                 fread((char*)Buff, 1, 12, fpTractogram);
-                fseek(fpTractogram,4*n_scalars,SEEK_CUR);
+                // fseek(fpTractogram,4*n_scalars,SEEK_CUR);
             }
             fseek(fpTractogram,4*n_properties,SEEK_CUR);
             f++;
-            OffsetArr[f] = ftell( fpTractogram );
+            current = ftell( fpTractogram );
+            for( int i = 1; i < threads_count; i++ ){
+                    if( f == Pos[i] ) 
+                        OffsetArr[i] = current;
+                }
         }
     } else {
 

--- a/commit/trk2dictionary/trk2dictionary_c.cpp
+++ b/commit/trk2dictionary/trk2dictionary_c.cpp
@@ -124,6 +124,11 @@ int trk2dictionary(
     minSegLen     = min_seg_len;
     minFiberLen   = min_fiber_len;
     maxFiberLen   = max_fiber_len;
+    totICSegments.resize( MAX_THREADS, 0 );
+    totFibers.resize( MAX_THREADS, 0 );
+    totECVoxels   = 0;
+    totECSegments = 0;
+
 
 
     printf("\n   \033[0;32m* %d concurrent threads are supported\n ", threads_count ); 
@@ -239,8 +244,7 @@ int trk2dictionary(
 
 
     printf( "     [ %d streamlines kept, %d segments in total ]\n", std::accumulate(totFibers.begin(), totFibers.end(), 0), std::accumulate( totICSegments.begin(), totICSegments.end(), 0) );
-    totFibers.clear();
-    totICSegments.clear();
+
     threads.clear();
     printf( "\n   \033[0;32m* Exporting EC compartments:\033[0m\n" );
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ setuptools>=46.1
 Cython>=0.29
 numpy>=1.12
 scipy>=1.0
-dmri-amico>=1.3.0
+dipy>=1.0
+dmri-dicelib>=1.0.0
+dmri-amico>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     cmdclass={'build_ext': CustomBuildExtCommand},
     ext_modules=get_extensions(),
     setup_requires=['Cython>=0.29', 'numpy>=1.12', 'wheel'],
-    install_requires=['setuptools>=46.1', 'Cython>=0.29', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'dmri-amico>=2.0.0'],
+    install_requires=['setuptools>=46.1', 'Cython>=0.29', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'dmri-dicelib>=1.0.0', 'dmri-amico>=2.0.0'],
     package_data={f'{package_name}.operator': ["*.*"]}
 )


### PR DESCRIPTION
### 🛠️Changed
- Default `ndirs=500` in `core.generate_kernels()` and in `trk2dictionary.run()`
- Expire the deprecated `ndirs` parameter in `amico.core.setup()`
- Expire the deprecated `filename_trk` and `gen_trk` parameters in `trk2dictionary.run()`
- Removed unused parameter `ndirs` from `trk2dictionary_c.cpp()`
- Build output goes into `build`
- Switched to proprietary license (see `LICENSE` file)

### ✨Added
- Added clustering in trk2dictionary.run()
    * geometry-based clustering using `blur_clust_thr` parameter
    * anatomical information streamlines clustering based on their endpoints using `blur_clust_groupby` parameter

- Added trk2dictionary.run() parallel computation using `n_threads` parameter
- Changed internal streamlines representation using `blur_core_extent` and `blur_gauss_extent` parameters
- Added possibility to keep temporal files created by parallel trk2dictionary.run() and clustering using `keep_temp` parameter
- Parallel compilation